### PR TITLE
Allows backend to update client module IDs dynamically

### DIFF
--- a/inc/adc_interface_client.hpp
+++ b/inc/adc_interface_client.hpp
@@ -31,20 +31,22 @@ class AdcInterfaceClient : public ClientAbstract {
     ClientEntry<float> adc_voltage_;
     ClientEntry<uint16_t> raw_value_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubRawValue + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &adc_voltage_,  // 0
-    //         &raw_value_     // 1
-    //     };
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    uint16_t GetNumberOfClientEntries(){
+      return kSubRawValue + 1;
+    }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubRawValue + 1;
+   void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
+
+      ClientEntryAbstract* entry_array[num_entries] = {
+          &adc_voltage_,  // 0
+          &raw_value_     // 1
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
    }
-
-   void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubAdcVoltage = 0;

--- a/inc/adc_interface_client.hpp
+++ b/inc/adc_interface_client.hpp
@@ -31,14 +31,20 @@ class AdcInterfaceClient : public ClientAbstract {
     ClientEntry<float> adc_voltage_;
     ClientEntry<uint16_t> raw_value_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubRawValue + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &adc_voltage_,  // 0
-            &raw_value_     // 1
-        };
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubRawValue + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &adc_voltage_,  // 0
+    //         &raw_value_     // 1
+    //     };
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubRawValue + 1;
+   }
+
+   void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubAdcVoltage = 0;

--- a/inc/anticogging_client.hpp
+++ b/inc/anticogging_client.hpp
@@ -38,25 +38,26 @@ class AnticoggingClient: public ClientAbstract{
     ClientEntryVoid erase_;
     ClientEntry<uint8_t> left_shift_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubLeftShift+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &table_size_,     // 0
-    //     &is_data_valid_,  // 1
-    //     &is_enabled_,     // 2
-    //     &erase_,          // 3
-    //     &left_shift_      // 4
-    //   };
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    uint16_t GetNumberOfClientEntries(){
+      return kSubLeftShift + 1;
+    }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubLeftShift + 1;
-   }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &table_size_,     // 0
+        &is_data_valid_,  // 1
+        &is_enabled_,     // 2
+        &erase_,          // 3
+        &left_shift_      // 4
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubTableSize    = 0;

--- a/inc/anticogging_client.hpp
+++ b/inc/anticogging_client.hpp
@@ -38,19 +38,25 @@ class AnticoggingClient: public ClientAbstract{
     ClientEntryVoid erase_;
     ClientEntry<uint8_t> left_shift_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubLeftShift+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &table_size_,     // 0
-        &is_data_valid_,  // 1
-        &is_enabled_,     // 2
-        &erase_,          // 3
-        &left_shift_      // 4
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubLeftShift+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &table_size_,     // 0
+    //     &is_data_valid_,  // 1
+    //     &is_enabled_,     // 2
+    //     &erase_,          // 3
+    //     &left_shift_      // 4
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubLeftShift + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubTableSize    = 0;

--- a/inc/anticogging_pro_client.hpp
+++ b/inc/anticogging_pro_client.hpp
@@ -8,9 +8,9 @@
 
 /*
   Name: anticogging_pro_client.hpp
-  Last update: 2023/06/29 by Ben Quan 
-  Author: Ben Quan 
-  Contributors: 
+  Last update: 2023/06/29 by Ben Quan
+  Author: Ben Quan
+  Contributors:
 */
 
 #ifndef ANTICOGGING_PRO_CLIENT_HPP
@@ -38,37 +38,43 @@ class AnticoggingProClient: public ClientAbstract{
       {};
 
     // Client Entries
-    ClientEntry<uint8_t>  enabled_;      
-    ClientEntry<float>    tau_;          
+    ClientEntry<uint8_t>  enabled_;
+    ClientEntry<float>    tau_;
     ClientEntry<uint8_t>  num_harmonics_;
-    ClientEntry<float>    voltage_;      
-    ClientEntry<uint8_t>  index_;        
-    ClientEntry<uint8_t>  harmonic_;     
-    ClientEntry<float>    a_;            
-    ClientEntry<float>    phase_;        
-    ClientEntry<float>    phase_total_;  
-    ClientEntry<float>    amplitude_;    
+    ClientEntry<float>    voltage_;
+    ClientEntry<uint8_t>  index_;
+    ClientEntry<uint8_t>  harmonic_;
+    ClientEntry<float>    a_;
+    ClientEntry<float>    phase_;
+    ClientEntry<float>    phase_total_;
+    ClientEntry<float>    amplitude_;
     ClientEntry<uint8_t>  max_harmonics_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubMaxHarmonics+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &enabled_,           // 0
-        &tau_,               // 1
-        &num_harmonics_,     // 2
-        &voltage_,           // 3
-        &index_,             // 4
-        &harmonic_,          // 5
-        &a_,                 // 6
-        &phase_,             // 7
-        &phase_total_,       // 8
-        &amplitude_,         // 9
-        &max_harmonics_      // 10
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubMaxHarmonics+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &enabled_,           // 0
+    //     &tau_,               // 1
+    //     &num_harmonics_,     // 2
+    //     &voltage_,           // 3
+    //     &index_,             // 4
+    //     &harmonic_,          // 5
+    //     &a_,                 // 6
+    //     &phase_,             // 7
+    //     &phase_total_,       // 8
+    //     &amplitude_,         // 9
+    //     &max_harmonics_      // 10
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubMaxHarmonics + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubEnabled       = 0;

--- a/inc/anticogging_pro_client.hpp
+++ b/inc/anticogging_pro_client.hpp
@@ -50,31 +50,31 @@ class AnticoggingProClient: public ClientAbstract{
     ClientEntry<float>    amplitude_;
     ClientEntry<uint8_t>  max_harmonics_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubMaxHarmonics+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &enabled_,           // 0
-    //     &tau_,               // 1
-    //     &num_harmonics_,     // 2
-    //     &voltage_,           // 3
-    //     &index_,             // 4
-    //     &harmonic_,          // 5
-    //     &a_,                 // 6
-    //     &phase_,             // 7
-    //     &phase_total_,       // 8
-    //     &amplitude_,         // 9
-    //     &max_harmonics_      // 10
-    //   };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubMaxHarmonics + 1;
+    }
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubMaxHarmonics + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &enabled_,           // 0
+        &tau_,               // 1
+        &num_harmonics_,     // 2
+        &voltage_,           // 3
+        &index_,             // 4
+        &harmonic_,          // 5
+        &a_,                 // 6
+        &phase_,             // 7
+        &phase_total_,       // 8
+        &amplitude_,         // 9
+        &max_harmonics_      // 10
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubEnabled       = 0;

--- a/inc/arming_handler_client.hpp
+++ b/inc/arming_handler_client.hpp
@@ -52,25 +52,51 @@ class ArmingHandlerClient : public ClientAbstract {
     ClientEntry<uint8_t> manual_arming_throttle_source_;
     ClientEntry<uint8_t> motor_armed_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubMotorArmed + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            nullptr,                                // 0
-            &always_armed_,                         // 1
-            &arm_on_throttle_,                      // 2
-            &arm_throttle_upper_limit_,             // 3
-            &arm_throttle_lower_limit_,             // 4
-            &disarm_on_throttle_,                   // 5
-            &disarm_throttle_upper_limit_,          // 6
-            &disarm_throttle_lower_limit_,          // 7
-            &consecutive_arming_throttles_to_arm_,  // 8
-            &disarm_behavior_,                      // 9
-            &disarm_song_option_,                   // 10
-            &manual_arming_throttle_source_,        // 11
-            &motor_armed_                           // 12
-        };
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubMotorArmed + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         nullptr,                                // 0
+    //         &always_armed_,                         // 1
+    //         &arm_on_throttle_,                      // 2
+    //         &arm_throttle_upper_limit_,             // 3
+    //         &arm_throttle_lower_limit_,             // 4
+    //         &disarm_on_throttle_,                   // 5
+    //         &disarm_throttle_upper_limit_,          // 6
+    //         &disarm_throttle_lower_limit_,          // 7
+    //         &consecutive_arming_throttles_to_arm_,  // 8
+    //         &disarm_behavior_,                      // 9
+    //         &disarm_song_option_,                   // 10
+    //         &manual_arming_throttle_source_,        // 11
+    //         &motor_armed_                           // 12
+    //     };
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubMotorArmed + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){
+    ClientEntryAbstract* entry_array[GetNumberOfClientEntries()] = {
+        nullptr,                                // 0
+        &always_armed_,                         // 1
+        &arm_on_throttle_,                      // 2
+        &arm_throttle_upper_limit_,             // 3
+        &arm_throttle_lower_limit_,             // 4
+        &disarm_on_throttle_,                   // 5
+        &disarm_throttle_upper_limit_,          // 6
+        &disarm_throttle_lower_limit_,          // 7
+        &consecutive_arming_throttles_to_arm_,  // 8
+        &disarm_behavior_,                      // 9
+        &disarm_song_option_,                   // 10
+        &manual_arming_throttle_source_,        // 11
+        &motor_armed_                           // 12
+    };
+
+    for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
+	    client_entries[entry] = entry_array[entry];
     }
+  }
 
    private:
     static const uint8_t kSubAlwaysArmed                     = 1;

--- a/inc/arming_handler_client.hpp
+++ b/inc/arming_handler_client.hpp
@@ -52,51 +52,33 @@ class ArmingHandlerClient : public ClientAbstract {
     ClientEntry<uint8_t> manual_arming_throttle_source_;
     ClientEntry<uint8_t> motor_armed_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubMotorArmed + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         nullptr,                                // 0
-    //         &always_armed_,                         // 1
-    //         &arm_on_throttle_,                      // 2
-    //         &arm_throttle_upper_limit_,             // 3
-    //         &arm_throttle_lower_limit_,             // 4
-    //         &disarm_on_throttle_,                   // 5
-    //         &disarm_throttle_upper_limit_,          // 6
-    //         &disarm_throttle_lower_limit_,          // 7
-    //         &consecutive_arming_throttles_to_arm_,  // 8
-    //         &disarm_behavior_,                      // 9
-    //         &disarm_song_option_,                   // 10
-    //         &manual_arming_throttle_source_,        // 11
-    //         &motor_armed_                           // 12
-    //     };
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
-
-   uint16_t GetNumberOfClientEntries(){
-	return kSubMotorArmed + 1;
-   }
-
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){
-    ClientEntryAbstract* entry_array[GetNumberOfClientEntries()] = {
-        nullptr,                                // 0
-        &always_armed_,                         // 1
-        &arm_on_throttle_,                      // 2
-        &arm_throttle_upper_limit_,             // 3
-        &arm_throttle_lower_limit_,             // 4
-        &disarm_on_throttle_,                   // 5
-        &disarm_throttle_upper_limit_,          // 6
-        &disarm_throttle_lower_limit_,          // 7
-        &consecutive_arming_throttles_to_arm_,  // 8
-        &disarm_behavior_,                      // 9
-        &disarm_song_option_,                   // 10
-        &manual_arming_throttle_source_,        // 11
-        &motor_armed_                           // 12
-    };
-
-    for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
-	    client_entries[entry] = entry_array[entry];
+    uint16_t GetNumberOfClientEntries(){
+      return kSubMotorArmed + 1;
     }
-  }
+
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
+
+      ClientEntryAbstract* entry_array[num_entries] = {
+          nullptr,                                // 0
+          &always_armed_,                         // 1
+          &arm_on_throttle_,                      // 2
+          &arm_throttle_upper_limit_,             // 3
+          &arm_throttle_lower_limit_,             // 4
+          &disarm_on_throttle_,                   // 5
+          &disarm_throttle_upper_limit_,          // 6
+          &disarm_throttle_lower_limit_,          // 7
+          &consecutive_arming_throttles_to_arm_,  // 8
+          &disarm_behavior_,                      // 9
+          &disarm_song_option_,                   // 10
+          &manual_arming_throttle_source_,        // 11
+          &motor_armed_                           // 12
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubAlwaysArmed                     = 1;

--- a/inc/brushless_drive_client.hpp
+++ b/inc/brushless_drive_client.hpp
@@ -144,82 +144,81 @@ class BrushlessDriveClient: public ClientAbstract{
     ClientEntry<float>      motoring_limit_ki_;
     ClientEntry<float>      motoring_limit_max_;
 
+    uint16_t GetNumberOfClientEntries(){
+      return kSubMotoringLimitMax + 1;
+    }
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubMotoringLimitMax+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &drive_mode_,                       // 0
-    //     &drive_phase_pwm_,                  // 1
-    //     &drive_phase_volts_,                // 2
-    //     &drive_spin_pwm_,                   // 3
-    //     &drive_spin_volts_,                 // 4
-    //     &drive_brake_,                      // 5
-    //     &drive_coast_,                      // 6
-    //     &drive_angle_offset_,               // 7
-    //     &drive_pwm_,                        // 8
-    //     &drive_volts_,                      // 9
-    //     &mech_lead_angle_,                  // 10
-    //     &obs_supply_volts_,                 // 11
-    //     &obs_angle_,                        // 12
-    //     &obs_velocity_,                     // 13
-    //     &motor_pole_pairs_,                 // 14
-    //     &motor_emf_shape_,                  // 15
-    //     &permute_wires_,                    // 16
-    //     &calibration_angle_,                // 17
-    //     &lead_time_,                        // 18
-    //     &commutation_hz_,                   // 19
-    //     &phase_angle_,                      // 20
-    //     &drive_volts_addition_,             // 21
-    //     &angle_adjust_enable_,              // 22
-    //     &motor_emf_calc_,                   // 23
-    //     &angle_adjustment_,                 // 24
-    //     &angle_adjust_max_,                 // 25
-    //     &angle_adjust_kp_,                  // 26
-    //     &angle_adjust_ki_,                  // 27
-    //     nullptr,                            // 28
-    //     &v_max_start_,                      // 29
-    //     nullptr,                            // 30
-    //     nullptr,                            // 31
-    //     &motor_Kv_,                         // 32
-    //     &motor_R_ohm_,                      // 33
-    //     &motor_I_max_,                      // 34
-    //     &volts_limit_,                      // 35
-    //     &est_motor_amps_,                   // 36
-    //     &est_motor_torque_,                 // 37
-    //     &motor_redline_start_,              // 38
-    //     &motor_redline_end_,                // 39
-    //     &motor_l_,                          // 40
-    //     &derate_,                           // 41
-    //     &motor_i_soft_start_,               // 42
-    //     &motor_i_soft_end_,                 // 43
-    //     &emf_,                              // 44
-    //     &volts_at_max_amps_,                // 45
-    //     &slew_volts_per_second_,            // 46
-    //     &slew_enable_,                      // 47
-    //     &motoring_supply_current_limit_,    // 48
-    //     &regen_supply_current_limit_,       // 49
-    //     &supply_current_limit_enable_,      // 50
-    //     &regen_limiting_,                   // 51
-    //     &regen_limit_adjust_,               // 52
-    //     &motoring_limiting_,                // 53
-    //     &motoring_limit_adjust_,            // 54
-    //     &regen_limit_kp_,                   // 55
-    //     &regen_limit_ki_,                   // 56
-    //     &regen_limit_max_,                  // 57
-    //     &motoring_limit_kp_,                // 58
-    //     &motoring_limit_ki_,                // 59
-    //     &motoring_limit_max_                // 60
-    //   };
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &drive_mode_,                       // 0
+        &drive_phase_pwm_,                  // 1
+        &drive_phase_volts_,                // 2
+        &drive_spin_pwm_,                   // 3
+        &drive_spin_volts_,                 // 4
+        &drive_brake_,                      // 5
+        &drive_coast_,                      // 6
+        &drive_angle_offset_,               // 7
+        &drive_pwm_,                        // 8
+        &drive_volts_,                      // 9
+        &mech_lead_angle_,                  // 10
+        &obs_supply_volts_,                 // 11
+        &obs_angle_,                        // 12
+        &obs_velocity_,                     // 13
+        &motor_pole_pairs_,                 // 14
+        &motor_emf_shape_,                  // 15
+        &permute_wires_,                    // 16
+        &calibration_angle_,                // 17
+        &lead_time_,                        // 18
+        &commutation_hz_,                   // 19
+        &phase_angle_,                      // 20
+        &drive_volts_addition_,             // 21
+        &angle_adjust_enable_,              // 22
+        &motor_emf_calc_,                   // 23
+        &angle_adjustment_,                 // 24
+        &angle_adjust_max_,                 // 25
+        &angle_adjust_kp_,                  // 26
+        &angle_adjust_ki_,                  // 27
+        nullptr,                            // 28
+        &v_max_start_,                      // 29
+        nullptr,                            // 30
+        nullptr,                            // 31
+        &motor_Kv_,                         // 32
+        &motor_R_ohm_,                      // 33
+        &motor_I_max_,                      // 34
+        &volts_limit_,                      // 35
+        &est_motor_amps_,                   // 36
+        &est_motor_torque_,                 // 37
+        &motor_redline_start_,              // 38
+        &motor_redline_end_,                // 39
+        &motor_l_,                          // 40
+        &derate_,                           // 41
+        &motor_i_soft_start_,               // 42
+        &motor_i_soft_end_,                 // 43
+        &emf_,                              // 44
+        &volts_at_max_amps_,                // 45
+        &slew_volts_per_second_,            // 46
+        &slew_enable_,                      // 47
+        &motoring_supply_current_limit_,    // 48
+        &regen_supply_current_limit_,       // 49
+        &supply_current_limit_enable_,      // 50
+        &regen_limiting_,                   // 51
+        &regen_limit_adjust_,               // 52
+        &motoring_limiting_,                // 53
+        &motoring_limit_adjust_,            // 54
+        &regen_limit_kp_,                   // 55
+        &regen_limit_ki_,                   // 56
+        &regen_limit_max_,                  // 57
+        &motoring_limit_kp_,                // 58
+        &motoring_limit_ki_,                // 59
+        &motoring_limit_max_                // 60
+      };
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubMotoringLimitMax + 1;
-   }
-
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubDriveMode                  = 0;

--- a/inc/brushless_drive_client.hpp
+++ b/inc/brushless_drive_client.hpp
@@ -48,11 +48,11 @@ class BrushlessDriveClient: public ClientAbstract{
       drive_volts_addition_(            kTypeBrushlessDrive, obj_idn, kSubDriveVoltsAddition),
       angle_adjust_enable_(             kTypeBrushlessDrive, obj_idn, kSubAngleAdjustEnable),
       motor_emf_calc_(                  kTypeBrushlessDrive, obj_idn, kSubMotorEmfCalc),
-      angle_adjustment_(                kTypeBrushlessDrive, obj_idn, kSubAngleAdjustment), 
-      angle_adjust_max_(                kTypeBrushlessDrive, obj_idn, kSubAngleAdjustMax),   
-      angle_adjust_kp_(                 kTypeBrushlessDrive, obj_idn, kSubAngleAdjustKp),    
-      angle_adjust_ki_(                 kTypeBrushlessDrive, obj_idn, kSubAngleAdjustKi),    
-      v_max_start_(                     kTypeBrushlessDrive, obj_idn, kSubVMaxStart),    
+      angle_adjustment_(                kTypeBrushlessDrive, obj_idn, kSubAngleAdjustment),
+      angle_adjust_max_(                kTypeBrushlessDrive, obj_idn, kSubAngleAdjustMax),
+      angle_adjust_kp_(                 kTypeBrushlessDrive, obj_idn, kSubAngleAdjustKp),
+      angle_adjust_ki_(                 kTypeBrushlessDrive, obj_idn, kSubAngleAdjustKi),
+      v_max_start_(                     kTypeBrushlessDrive, obj_idn, kSubVMaxStart),
       motor_Kv_(                        kTypeBrushlessDrive, obj_idn, kSubMotorKv),
       motor_R_ohm_(                     kTypeBrushlessDrive, obj_idn, kSubMotorROhm),
       motor_I_max_(                     kTypeBrushlessDrive, obj_idn, kSubMotorIMax),
@@ -63,22 +63,22 @@ class BrushlessDriveClient: public ClientAbstract{
       motor_redline_end_(               kTypeBrushlessDrive, obj_idn, kSubMotorRedlineEnd),
       motor_l_(                         kTypeBrushlessDrive, obj_idn, kSubMotorL),
       derate_(                          kTypeBrushlessDrive, obj_idn, kSubDerate),
-      motor_i_soft_start_(              kTypeBrushlessDrive, obj_idn, kSubMotorISoftStart),            
-      motor_i_soft_end_(                kTypeBrushlessDrive, obj_idn, kSubMotorISoftEnd),             
-      emf_(                             kTypeBrushlessDrive, obj_idn, kSubEmf),                       
-      volts_at_max_amps_(               kTypeBrushlessDrive, obj_idn, kSubVoltsAtMaxAmps),            
-      slew_volts_per_second_(           kTypeBrushlessDrive, obj_idn, kSubSlewVoltsPerSecond),        
-      slew_enable_(                     kTypeBrushlessDrive, obj_idn, kSubSlewEnable),                
+      motor_i_soft_start_(              kTypeBrushlessDrive, obj_idn, kSubMotorISoftStart),
+      motor_i_soft_end_(                kTypeBrushlessDrive, obj_idn, kSubMotorISoftEnd),
+      emf_(                             kTypeBrushlessDrive, obj_idn, kSubEmf),
+      volts_at_max_amps_(               kTypeBrushlessDrive, obj_idn, kSubVoltsAtMaxAmps),
+      slew_volts_per_second_(           kTypeBrushlessDrive, obj_idn, kSubSlewVoltsPerSecond),
+      slew_enable_(                     kTypeBrushlessDrive, obj_idn, kSubSlewEnable),
       motoring_supply_current_limit_(   kTypeBrushlessDrive, obj_idn, kSubMotoringSupplyCurrentLimit),
       regen_supply_current_limit_(      kTypeBrushlessDrive, obj_idn, kSubRegenSupplyCurrentLimit),
       supply_current_limit_enable_(     kTypeBrushlessDrive, obj_idn, kSubSupplyCurrentLimitEnable),
-      regen_limiting_(                  kTypeBrushlessDrive, obj_idn, kSubRegenLimiting),             
-      regen_limit_adjust_(              kTypeBrushlessDrive, obj_idn, kSubRegenLimitAdjust),          
-      motoring_limiting_(               kTypeBrushlessDrive, obj_idn, kSubMotoringLimiting),          
+      regen_limiting_(                  kTypeBrushlessDrive, obj_idn, kSubRegenLimiting),
+      regen_limit_adjust_(              kTypeBrushlessDrive, obj_idn, kSubRegenLimitAdjust),
+      motoring_limiting_(               kTypeBrushlessDrive, obj_idn, kSubMotoringLimiting),
       motoring_limit_adjust_(           kTypeBrushlessDrive, obj_idn, kSubMotoringLimitAdjust),
       regen_limit_kp_(                  kTypeBrushlessDrive, obj_idn, kSubRegenLimitKp),
-      regen_limit_ki_(                  kTypeBrushlessDrive, obj_idn, kSubRegenLimitKi),              
-      regen_limit_max_(                 kTypeBrushlessDrive, obj_idn, kSubRegenLimitMax),             
+      regen_limit_ki_(                  kTypeBrushlessDrive, obj_idn, kSubRegenLimitKi),
+      regen_limit_max_(                 kTypeBrushlessDrive, obj_idn, kSubRegenLimitMax),
       motoring_limit_kp_(               kTypeBrushlessDrive, obj_idn, kSubMotoringLimitKp),
       motoring_limit_ki_(               kTypeBrushlessDrive, obj_idn, kSubMotoringLimitKi),
       motoring_limit_max_(              kTypeBrushlessDrive, obj_idn, kSubMotoringLimitMax)
@@ -107,13 +107,13 @@ class BrushlessDriveClient: public ClientAbstract{
     ClientEntry<uint32_t>   commutation_hz_;
     ClientEntry<float>      phase_angle_;
     ClientEntry<float>      drive_volts_addition_;
-    ClientEntry<uint8_t>    angle_adjust_enable_; 
-    ClientEntry<float>      motor_emf_calc_;      
-    ClientEntry<float>      angle_adjustment_;    
-    ClientEntry<float>      angle_adjust_max_;    
-    ClientEntry<float>      angle_adjust_kp_;     
-    ClientEntry<float>      angle_adjust_ki_;        
-    ClientEntry<float>      v_max_start_;        
+    ClientEntry<uint8_t>    angle_adjust_enable_;
+    ClientEntry<float>      motor_emf_calc_;
+    ClientEntry<float>      angle_adjustment_;
+    ClientEntry<float>      angle_adjust_max_;
+    ClientEntry<float>      angle_adjust_kp_;
+    ClientEntry<float>      angle_adjust_ki_;
+    ClientEntry<float>      v_max_start_;
     ClientEntry<float>      motor_Kv_;
     ClientEntry<float>      motor_R_ohm_;
     ClientEntry<float>      motor_I_max_;
@@ -145,75 +145,81 @@ class BrushlessDriveClient: public ClientAbstract{
     ClientEntry<float>      motoring_limit_max_;
 
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubMotoringLimitMax+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &drive_mode_,                       // 0
-        &drive_phase_pwm_,                  // 1
-        &drive_phase_volts_,                // 2
-        &drive_spin_pwm_,                   // 3
-        &drive_spin_volts_,                 // 4
-        &drive_brake_,                      // 5
-        &drive_coast_,                      // 6
-        &drive_angle_offset_,               // 7
-        &drive_pwm_,                        // 8
-        &drive_volts_,                      // 9
-        &mech_lead_angle_,                  // 10
-        &obs_supply_volts_,                 // 11
-        &obs_angle_,                        // 12
-        &obs_velocity_,                     // 13
-        &motor_pole_pairs_,                 // 14
-        &motor_emf_shape_,                  // 15
-        &permute_wires_,                    // 16
-        &calibration_angle_,                // 17
-        &lead_time_,                        // 18
-        &commutation_hz_,                   // 19
-        &phase_angle_,                      // 20
-        &drive_volts_addition_,             // 21
-        &angle_adjust_enable_,              // 22
-        &motor_emf_calc_,                   // 23
-        &angle_adjustment_,                 // 24
-        &angle_adjust_max_,                 // 25
-        &angle_adjust_kp_,                  // 26
-        &angle_adjust_ki_,                  // 27
-        nullptr,                            // 28
-        &v_max_start_,                      // 29
-        nullptr,                            // 30
-        nullptr,                            // 31
-        &motor_Kv_,                         // 32
-        &motor_R_ohm_,                      // 33
-        &motor_I_max_,                      // 34
-        &volts_limit_,                      // 35
-        &est_motor_amps_,                   // 36
-        &est_motor_torque_,                 // 37
-        &motor_redline_start_,              // 38
-        &motor_redline_end_,                // 39
-        &motor_l_,                          // 40
-        &derate_,                           // 41
-        &motor_i_soft_start_,               // 42 
-        &motor_i_soft_end_,                 // 43 
-        &emf_,                              // 44 
-        &volts_at_max_amps_,                // 45   
-        &slew_volts_per_second_,            // 46 
-        &slew_enable_,                      // 47 
-        &motoring_supply_current_limit_,    // 48
-        &regen_supply_current_limit_,       // 49
-        &supply_current_limit_enable_,      // 50
-        &regen_limiting_,                   // 51
-        &regen_limit_adjust_,               // 52
-        &motoring_limiting_,                // 53
-        &motoring_limit_adjust_,            // 54
-        &regen_limit_kp_,                   // 55
-        &regen_limit_ki_,                   // 56
-        &regen_limit_max_,                  // 57
-        &motoring_limit_kp_,                // 58
-        &motoring_limit_ki_,                // 59
-        &motoring_limit_max_                // 60
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubMotoringLimitMax+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &drive_mode_,                       // 0
+    //     &drive_phase_pwm_,                  // 1
+    //     &drive_phase_volts_,                // 2
+    //     &drive_spin_pwm_,                   // 3
+    //     &drive_spin_volts_,                 // 4
+    //     &drive_brake_,                      // 5
+    //     &drive_coast_,                      // 6
+    //     &drive_angle_offset_,               // 7
+    //     &drive_pwm_,                        // 8
+    //     &drive_volts_,                      // 9
+    //     &mech_lead_angle_,                  // 10
+    //     &obs_supply_volts_,                 // 11
+    //     &obs_angle_,                        // 12
+    //     &obs_velocity_,                     // 13
+    //     &motor_pole_pairs_,                 // 14
+    //     &motor_emf_shape_,                  // 15
+    //     &permute_wires_,                    // 16
+    //     &calibration_angle_,                // 17
+    //     &lead_time_,                        // 18
+    //     &commutation_hz_,                   // 19
+    //     &phase_angle_,                      // 20
+    //     &drive_volts_addition_,             // 21
+    //     &angle_adjust_enable_,              // 22
+    //     &motor_emf_calc_,                   // 23
+    //     &angle_adjustment_,                 // 24
+    //     &angle_adjust_max_,                 // 25
+    //     &angle_adjust_kp_,                  // 26
+    //     &angle_adjust_ki_,                  // 27
+    //     nullptr,                            // 28
+    //     &v_max_start_,                      // 29
+    //     nullptr,                            // 30
+    //     nullptr,                            // 31
+    //     &motor_Kv_,                         // 32
+    //     &motor_R_ohm_,                      // 33
+    //     &motor_I_max_,                      // 34
+    //     &volts_limit_,                      // 35
+    //     &est_motor_amps_,                   // 36
+    //     &est_motor_torque_,                 // 37
+    //     &motor_redline_start_,              // 38
+    //     &motor_redline_end_,                // 39
+    //     &motor_l_,                          // 40
+    //     &derate_,                           // 41
+    //     &motor_i_soft_start_,               // 42
+    //     &motor_i_soft_end_,                 // 43
+    //     &emf_,                              // 44
+    //     &volts_at_max_amps_,                // 45
+    //     &slew_volts_per_second_,            // 46
+    //     &slew_enable_,                      // 47
+    //     &motoring_supply_current_limit_,    // 48
+    //     &regen_supply_current_limit_,       // 49
+    //     &supply_current_limit_enable_,      // 50
+    //     &regen_limiting_,                   // 51
+    //     &regen_limit_adjust_,               // 52
+    //     &motoring_limiting_,                // 53
+    //     &motoring_limit_adjust_,            // 54
+    //     &regen_limit_kp_,                   // 55
+    //     &regen_limit_ki_,                   // 56
+    //     &regen_limit_max_,                  // 57
+    //     &motoring_limit_kp_,                // 58
+    //     &motoring_limit_ki_,                // 59
+    //     &motoring_limit_max_                // 60
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubMotoringLimitMax + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubDriveMode                  = 0;

--- a/inc/buzzer_control_client.hpp
+++ b/inc/buzzer_control_client.hpp
@@ -44,22 +44,28 @@ class BuzzerControlClient: public ClientAbstract{
     ClientEntry<uint8_t>  volume_;
     ClientEntry<uint16_t> duration_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubDuration+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &ctrl_mode_,  // 0
-        &ctrl_brake_, // 1
-        &ctrl_coast_, // 2
-        &ctrl_note_,  // 3
-        &volume_max_, // 4
-        &hz_,         // 5
-        &volume_,     // 6
-        &duration_,   // 7
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubDuration+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &ctrl_mode_,  // 0
+    //     &ctrl_brake_, // 1
+    //     &ctrl_coast_, // 2
+    //     &ctrl_note_,  // 3
+    //     &volume_max_, // 4
+    //     &hz_,         // 5
+    //     &volume_,     // 6
+    //     &duration_,   // 7
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubDuration + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubCtrlMode   = 0;

--- a/inc/buzzer_control_client.hpp
+++ b/inc/buzzer_control_client.hpp
@@ -44,28 +44,28 @@ class BuzzerControlClient: public ClientAbstract{
     ClientEntry<uint8_t>  volume_;
     ClientEntry<uint16_t> duration_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubDuration+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &ctrl_mode_,  // 0
-    //     &ctrl_brake_, // 1
-    //     &ctrl_coast_, // 2
-    //     &ctrl_note_,  // 3
-    //     &volume_max_, // 4
-    //     &hz_,         // 5
-    //     &volume_,     // 6
-    //     &duration_,   // 7
-    //   };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubDuration + 1;
+    }
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubDuration + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &ctrl_mode_,  // 0
+        &ctrl_brake_, // 1
+        &ctrl_coast_, // 2
+        &ctrl_note_,  // 3
+        &volume_max_, // 4
+        &hz_,         // 5
+        &volume_,     // 6
+        &duration_,   // 7
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubCtrlMode   = 0;

--- a/inc/client_communication.cpp
+++ b/inc/client_communication.cpp
@@ -68,3 +68,11 @@ int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
   }
   return 0; // I didn't parse anything
 }
+
+void UpdateEntryIdsFromList(ClientEntryAbstract** entry_array, uint8_t entry_length, uint8_t new_id){
+  for(uint8_t entry = 0; entry < entry_length; entry++){
+    if(entry_array[entry] != nullptr){
+      entry_array[entry]->UpdateModuleId(new_id);
+    }
+  }
+}

--- a/inc/client_communication.cpp
+++ b/inc/client_communication.cpp
@@ -36,9 +36,10 @@ int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
         if(entry_array[sub_idn]->type_idn_ == type_idn &&
         entry_array[sub_idn]->obj_idn_ == obj_idn)
         {
-          // ... then we have a valid message
-          entry_array[sub_idn]->Reply(&rx_data[3],rx_length-3);
-          return 1; // I parsed something
+          return 1;
+      //     // ... then we have a valid message
+      //     entry_array[sub_idn]->Reply(&rx_data[3],rx_length-3);
+      //     return 1; // I parsed something
         }
       }
     }

--- a/inc/client_communication.cpp
+++ b/inc/client_communication.cpp
@@ -36,10 +36,9 @@ int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
         if(entry_array[sub_idn]->type_idn_ == type_idn &&
         entry_array[sub_idn]->obj_idn_ == obj_idn)
         {
-          return 1;
-      //     // ... then we have a valid message
-      //     entry_array[sub_idn]->Reply(&rx_data[3],rx_length-3);
-      //     return 1; // I parsed something
+          // ... then we have a valid message
+          entry_array[sub_idn]->Reply(&rx_data[3],rx_length-3);
+          return 1; // I parsed something
         }
       }
     }

--- a/inc/client_communication.cpp
+++ b/inc/client_communication.cpp
@@ -68,11 +68,3 @@ int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
   }
   return 0; // I didn't parse anything
 }
-
-void UpdateEntryIdsFromList(ClientEntryAbstract** entry_array, uint8_t entry_length, uint8_t new_id){
-  for(uint8_t entry = 0; entry < entry_length; entry++){
-    if(entry_array[entry] != nullptr){
-      entry_array[entry]->UpdateModuleId(new_id);
-    }
-  }
-}

--- a/inc/client_communication.hpp
+++ b/inc/client_communication.hpp
@@ -212,13 +212,15 @@ class ClientAbstract{
     }
 
     void UpdateEntryIds(uint8_t new_id){
-      // if(entry_array_head != nullptr){
-      //   for(uint8_t entry = 0; entry < num_entries; entry++){
-      //     if(entry_array_head[entry] != nullptr){
-      //       entry_array_head[entry]->UpdateModuleId(new_id);
-      //     }
-      //   }
-      // }
+      uint8_t number_of_entries = GetNumberOfClientEntries();
+      ClientEntryAbstract * client_array[number_of_entries];
+      GetClientEntryList(client_array);
+
+      for(uint8_t entry = 0; entry < number_of_entries; entry++){
+        if(client_array[entry] != nullptr){
+          client_array[entry]->UpdateModuleId(new_id);
+        }
+      }
     }
 
     virtual uint16_t GetNumberOfClientEntries() = 0;

--- a/inc/client_communication.hpp
+++ b/inc/client_communication.hpp
@@ -204,6 +204,8 @@ class ClientAbstract{
 
     void UpdateModuleId(uint8_t new_id){
       obj_idn_ = new_id;
+
+      UpdateEntryIds(new_id);
     }
 
     void UpdateEntryIds(uint8_t new_id){

--- a/inc/client_communication.hpp
+++ b/inc/client_communication.hpp
@@ -32,8 +32,12 @@ class ClientEntryAbstract {
 
     virtual void Reply(const uint8_t* data, uint8_t len) = 0;
 
+    virtual void UpdateModuleId(uint8_t new_id){
+      obj_idn_ = new_id;
+    }
+
     const uint8_t type_idn_;
-    const uint8_t obj_idn_;
+    uint8_t obj_idn_;
     const uint8_t sub_idn_;
 };
 
@@ -131,7 +135,7 @@ class ClientEntry: public ClientEntryAbstract {
 class PackedClientEntry : public ClientEntryAbstract {
   public:
     PackedClientEntry(uint8_t type_idn, uint8_t obj_idn, uint8_t sub_idn, uint8_t * data_buf):
-      ClientEntryAbstract(type_idn, obj_idn, sub_idn),    
+      ClientEntryAbstract(type_idn, obj_idn, sub_idn),
       data_buf_(data_buf)
     {};
 
@@ -164,7 +168,7 @@ class PackedClientEntry : public ClientEntryAbstract {
         memcpy(output_buf, data_buf_, output_len);
       }
     };
-    
+
     bool IsFresh() {return is_fresh_;};
 
   private:
@@ -183,8 +187,14 @@ class ClientAbstract{
 
     virtual void ReadMsg(uint8_t* rx_data, uint8_t rx_length) = 0;
 
+    void UpdateModuleId(uint8_t new_id){
+      obj_idn_ = new_id;
+    }
+
+    virtual void UpdateEntryIds(uint8_t new_id){}
+
     const uint8_t type_idn_;
-    const uint8_t obj_idn_;
+    uint8_t obj_idn_;
 };
 
 int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
@@ -192,5 +202,7 @@ int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
 
 int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
   ClientEntryAbstract& entry);
+
+void UpdateEntryIdsFromList(ClientEntryAbstract** entry_array, uint8_t entry_length, uint8_t new_id);
 
 #endif // CLIENT_COMMUNICATION_H

--- a/inc/client_communication.hpp
+++ b/inc/client_communication.hpp
@@ -215,6 +215,4 @@ int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
 int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
   ClientEntryAbstract& entry);
 
-void UpdateEntryIdsFromList(ClientEntryAbstract** entry_array, uint8_t entry_length, uint8_t new_id);
-
 #endif // CLIENT_COMMUNICATION_H

--- a/inc/client_communication.hpp
+++ b/inc/client_communication.hpp
@@ -181,7 +181,9 @@ class ClientAbstract{
   public:
     ClientAbstract(uint8_t type_idn, uint8_t obj_idn):
       type_idn_(type_idn),
-      obj_idn_(obj_idn) {};
+      obj_idn_(obj_idn),
+      entry_array_head(nullptr),
+      num_entries(0) {};
 
     virtual ~ClientAbstract(){};
 
@@ -191,10 +193,20 @@ class ClientAbstract{
       obj_idn_ = new_id;
     }
 
-    virtual void UpdateEntryIds(uint8_t new_id){}
+    void UpdateEntryIds(uint8_t new_id){
+      if(entry_array_head != nullptr){
+        for(uint8_t entry = 0; entry < num_entries; entry++){
+          if(entry_array_head[entry] != nullptr){
+            entry_array_head[entry]->UpdateModuleId(new_id);
+          }
+        }
+      }
+    }
 
     const uint8_t type_idn_;
     uint8_t obj_idn_;
+    ClientEntryAbstract** entry_array_head;
+    uint8_t num_entries;
 };
 
 int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,

--- a/inc/client_communication.hpp
+++ b/inc/client_communication.hpp
@@ -177,42 +177,55 @@ class PackedClientEntry : public ClientEntryAbstract {
 
 };
 
+int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
+  ClientEntryAbstract** entry_array, uint8_t entry_length);
+
+int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
+  ClientEntryAbstract& entry);
+
 class ClientAbstract{
   public:
     ClientAbstract(uint8_t type_idn, uint8_t obj_idn):
       type_idn_(type_idn),
-      obj_idn_(obj_idn),
-      entry_array_head(nullptr),
-      num_entries(0) {};
+      obj_idn_(obj_idn)
+      {};
 
     virtual ~ClientAbstract(){};
 
-    virtual void ReadMsg(uint8_t* rx_data, uint8_t rx_length) = 0;
+  int8_t ReadMsg(uint8_t* rx_data, uint8_t rx_length){
+    uint8_t number_of_entries = GetNumberOfClientEntries();
+    ClientEntryAbstract * client_array[number_of_entries];
+
+    GetClientEntryList(client_array);
+
+    if(client_array != nullptr){
+      int8_t parse_result = ParseMsg(rx_data, rx_length, client_array, number_of_entries);
+
+      return parse_result;
+    }
+
+    return -1;
+  }
 
     void UpdateModuleId(uint8_t new_id){
       obj_idn_ = new_id;
     }
 
     void UpdateEntryIds(uint8_t new_id){
-      if(entry_array_head != nullptr){
-        for(uint8_t entry = 0; entry < num_entries; entry++){
-          if(entry_array_head[entry] != nullptr){
-            entry_array_head[entry]->UpdateModuleId(new_id);
-          }
-        }
-      }
+      // if(entry_array_head != nullptr){
+      //   for(uint8_t entry = 0; entry < num_entries; entry++){
+      //     if(entry_array_head[entry] != nullptr){
+      //       entry_array_head[entry]->UpdateModuleId(new_id);
+      //     }
+      //   }
+      // }
     }
+
+    virtual uint16_t GetNumberOfClientEntries() = 0;
+    virtual void GetClientEntryList(ClientEntryAbstract ** client_entries) = 0;
 
     const uint8_t type_idn_;
     uint8_t obj_idn_;
-    ClientEntryAbstract** entry_array_head;
-    uint8_t num_entries;
 };
-
-int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
-  ClientEntryAbstract** entry_array, uint8_t entry_length);
-
-int8_t ParseMsg(uint8_t* rx_data, uint8_t rx_length,
-  ClientEntryAbstract& entry);
 
 #endif // CLIENT_COMMUNICATION_H

--- a/inc/client_communication.hpp
+++ b/inc/client_communication.hpp
@@ -195,16 +195,11 @@ class ClientAbstract{
   int8_t ReadMsg(uint8_t* rx_data, uint8_t rx_length){
     uint8_t number_of_entries = GetNumberOfClientEntries();
     ClientEntryAbstract * client_array[number_of_entries];
-
     GetClientEntryList(client_array);
 
-    if(client_array != nullptr){
-      int8_t parse_result = ParseMsg(rx_data, rx_length, client_array, number_of_entries);
+    int8_t parse_result = ParseMsg(rx_data, rx_length, client_array, number_of_entries);
 
-      return parse_result;
-    }
-
-    return -1;
+    return parse_result;
   }
 
     void UpdateModuleId(uint8_t new_id){

--- a/inc/coil_temperature_estimator_client.hpp
+++ b/inc/coil_temperature_estimator_client.hpp
@@ -68,38 +68,40 @@ class CoilTemperatureEstimatorClient : public ClientAbstract {
     ClientEntry<float> q_lam_alu_;
     ClientEntry<float> t_lam_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubTLam + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &t_coil_,                        // 0
-    //         &t_alu_,                         // 1
-    //         &t_amb_,                         // 2
-    //         &h_coil_amb_free_conv_,          // 3
-    //         &h_coil_stator_cond_,            // 4
-    //         &h_coil_amb_forced_conv_,        // 5
-    //         &c_coil_,                        // 6
-    //         &h_coil_amb_forced_conv_coeff_,  // 7
-    //         &otw_,                           // 8
-    //         &otlo_,                          // 9
-    //         &derate_,                        // 10
-    //         &q_coil_joule_,                  // 11
-    //         &q_coil_amb_conv_,               // 12
-    //         &q_coil_stator_cond_,            // 13
-    //         &h_lam_alu_,                     // 14
-    //         &c_lam_,                         // 15
-    //         &k_lam_hist_coeff_,              // 16
-    //         &q_lam_hist_,                    // 17
-    //         &q_lam_alu_,                     // 18
-    //         &t_lam_                          // 19
-    //     };
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    uint16_t GetNumberOfClientEntries(){
+      return kSubTLam + 1;
+    }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubTLam + 1;
-   }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      ClientEntryAbstract* entry_array[num_entries] = {
+          &t_coil_,                        // 0
+          &t_alu_,                         // 1
+          &t_amb_,                         // 2
+          &h_coil_amb_free_conv_,          // 3
+          &h_coil_stator_cond_,            // 4
+          &h_coil_amb_forced_conv_,        // 5
+          &c_coil_,                        // 6
+          &h_coil_amb_forced_conv_coeff_,  // 7
+          &otw_,                           // 8
+          &otlo_,                          // 9
+          &derate_,                        // 10
+          &q_coil_joule_,                  // 11
+          &q_coil_amb_conv_,               // 12
+          &q_coil_stator_cond_,            // 13
+          &h_lam_alu_,                     // 14
+          &c_lam_,                         // 15
+          &k_lam_hist_coeff_,              // 16
+          &q_lam_hist_,                    // 17
+          &q_lam_alu_,                     // 18
+          &t_lam_                          // 19
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubTCoil                   = 0;

--- a/inc/coil_temperature_estimator_client.hpp
+++ b/inc/coil_temperature_estimator_client.hpp
@@ -68,32 +68,38 @@ class CoilTemperatureEstimatorClient : public ClientAbstract {
     ClientEntry<float> q_lam_alu_;
     ClientEntry<float> t_lam_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubTLam + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &t_coil_,                        // 0
-            &t_alu_,                         // 1
-            &t_amb_,                         // 2
-            &h_coil_amb_free_conv_,          // 3
-            &h_coil_stator_cond_,            // 4
-            &h_coil_amb_forced_conv_,        // 5
-            &c_coil_,                        // 6
-            &h_coil_amb_forced_conv_coeff_,  // 7
-            &otw_,                           // 8
-            &otlo_,                          // 9
-            &derate_,                        // 10
-            &q_coil_joule_,                  // 11
-            &q_coil_amb_conv_,               // 12
-            &q_coil_stator_cond_,            // 13
-            &h_lam_alu_,                     // 14
-            &c_lam_,                         // 15
-            &k_lam_hist_coeff_,              // 16
-            &q_lam_hist_,                    // 17
-            &q_lam_alu_,                     // 18
-            &t_lam_                          // 19
-        };
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubTLam + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &t_coil_,                        // 0
+    //         &t_alu_,                         // 1
+    //         &t_amb_,                         // 2
+    //         &h_coil_amb_free_conv_,          // 3
+    //         &h_coil_stator_cond_,            // 4
+    //         &h_coil_amb_forced_conv_,        // 5
+    //         &c_coil_,                        // 6
+    //         &h_coil_amb_forced_conv_coeff_,  // 7
+    //         &otw_,                           // 8
+    //         &otlo_,                          // 9
+    //         &derate_,                        // 10
+    //         &q_coil_joule_,                  // 11
+    //         &q_coil_amb_conv_,               // 12
+    //         &q_coil_stator_cond_,            // 13
+    //         &h_lam_alu_,                     // 14
+    //         &c_lam_,                         // 15
+    //         &k_lam_hist_coeff_,              // 16
+    //         &q_lam_hist_,                    // 17
+    //         &q_lam_alu_,                     // 18
+    //         &t_lam_                          // 19
+    //     };
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubTLam + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubTCoil                   = 0;

--- a/inc/esc_propeller_input_parser_client.hpp
+++ b/inc/esc_propeller_input_parser_client.hpp
@@ -67,6 +67,25 @@ class EscPropellerInputParserClient : public ClientAbstract {
         ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
     }
 
+    void UpdateEntryIds(uint8_t new_id){
+        static const uint8_t kEntryLength = kSubZeroSpinTolerance + 1;
+        ClientEntryAbstract* entry_array[kEntryLength] = {
+            &mode_,                // 0
+            &raw_value_,           // 1
+            nullptr,               // 2
+            &sign_,                // 3
+            &volts_max_,           // 4
+            &velocity_max_,        // 5
+            &thrust_max_,          // 6
+            &safe_factor_,         // 7
+            &flip_negative_,       // 8
+            &zero_spin_throttle_,  // 9
+            &zero_spin_tolerance_  // 10
+        };
+
+        UpdateEntryIdsFromList(entry_array, kEntryLength, new_id);
+    }
+
    private:
     static const uint8_t kSubMode              = 0;
     static const uint8_t kSubRawValue          = 1;

--- a/inc/esc_propeller_input_parser_client.hpp
+++ b/inc/esc_propeller_input_parser_client.hpp
@@ -35,8 +35,6 @@ class EscPropellerInputParserClient : public ClientAbstract {
           zero_spin_throttle_(kTypeEscPropellerInputParser, obj_idn, kSubZeroSpinThrottle),
           zero_spin_tolerance_(kTypeEscPropellerInputParser, obj_idn, kSubZeroSpinTolerance)
           {
-            entry_array_head = entry_array;
-            num_entries = kEntryLength;
           };
 
     // Client Entries
@@ -52,24 +50,12 @@ class EscPropellerInputParserClient : public ClientAbstract {
     ClientEntry<float> zero_spin_throttle_;
     ClientEntry<float> zero_spin_tolerance_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+   uint16_t GetNumberOfClientEntries(){
+	   return kSubZeroSpinTolerance + 1;
+   }
 
-   private:
-    static const uint8_t kSubMode              = 0;
-    static const uint8_t kSubRawValue          = 1;
-    static const uint8_t kSubSign              = 3;
-    static const uint8_t kSubVoltsMax          = 4;
-    static const uint8_t kSubVelocityMax       = 5;
-    static const uint8_t kSubThrustMax         = 6;
-    static const uint8_t kSubSafeFactor        = 7;
-    static const uint8_t kSubFlipNegative      = 8;
-    static const uint8_t kSubZeroSpinThrottle  = 9;
-    static const uint8_t kSubZeroSpinTolerance = 10;
-
-    static const uint8_t kEntryLength = kSubZeroSpinTolerance + 1;
-    ClientEntryAbstract* entry_array[kEntryLength] = {
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){
+    ClientEntryAbstract* entry_array[GetNumberOfClientEntries()] = {
         &mode_,                // 0
         &raw_value_,           // 1
         nullptr,               // 2
@@ -82,6 +68,23 @@ class EscPropellerInputParserClient : public ClientAbstract {
         &zero_spin_throttle_,  // 9
         &zero_spin_tolerance_  // 10
     };
+
+    for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
+	    client_entries[entry] = entry_array[entry];
+    }
+  }
+
+   private:
+    static const uint8_t kSubMode              = 0;
+    static const uint8_t kSubRawValue          = 1;
+    static const uint8_t kSubSign              = 3;
+    static const uint8_t kSubVoltsMax          = 4;
+    static const uint8_t kSubVelocityMax       = 5;
+    static const uint8_t kSubThrustMax         = 6;
+    static const uint8_t kSubSafeFactor        = 7;
+    static const uint8_t kSubFlipNegative      = 8;
+    static const uint8_t kSubZeroSpinThrottle  = 9;
+    static const uint8_t kSubZeroSpinTolerance = 10;
 };
 
 #endif /* ESC_PROPELLER_INPUT_PARSER_CLIENT_HPP_ */

--- a/inc/esc_propeller_input_parser_client.hpp
+++ b/inc/esc_propeller_input_parser_client.hpp
@@ -33,7 +33,11 @@ class EscPropellerInputParserClient : public ClientAbstract {
           safe_factor_(kTypeEscPropellerInputParser, obj_idn, kSubSafeFactor),
           flip_negative_(kTypeEscPropellerInputParser, obj_idn, kSubFlipNegative),
           zero_spin_throttle_(kTypeEscPropellerInputParser, obj_idn, kSubZeroSpinThrottle),
-          zero_spin_tolerance_(kTypeEscPropellerInputParser, obj_idn, kSubZeroSpinTolerance){};
+          zero_spin_tolerance_(kTypeEscPropellerInputParser, obj_idn, kSubZeroSpinTolerance)
+          {
+            entry_array_head = entry_array;
+            num_entries = kEntryLength;
+          };
 
     // Client Entries
     // Control commands
@@ -49,41 +53,7 @@ class EscPropellerInputParserClient : public ClientAbstract {
     ClientEntry<float> zero_spin_tolerance_;
 
     void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubZeroSpinTolerance + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &mode_,                // 0
-            &raw_value_,           // 1
-            nullptr,               // 2
-            &sign_,                // 3
-            &volts_max_,           // 4
-            &velocity_max_,        // 5
-            &thrust_max_,          // 6
-            &safe_factor_,         // 7
-            &flip_negative_,       // 8
-            &zero_spin_throttle_,  // 9
-            &zero_spin_tolerance_  // 10
-        };
-
         ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
-
-    void UpdateEntryIds(uint8_t new_id){
-        static const uint8_t kEntryLength = kSubZeroSpinTolerance + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &mode_,                // 0
-            &raw_value_,           // 1
-            nullptr,               // 2
-            &sign_,                // 3
-            &volts_max_,           // 4
-            &velocity_max_,        // 5
-            &thrust_max_,          // 6
-            &safe_factor_,         // 7
-            &flip_negative_,       // 8
-            &zero_spin_throttle_,  // 9
-            &zero_spin_tolerance_  // 10
-        };
-
-        UpdateEntryIdsFromList(entry_array, kEntryLength, new_id);
     }
 
    private:
@@ -97,6 +67,21 @@ class EscPropellerInputParserClient : public ClientAbstract {
     static const uint8_t kSubFlipNegative      = 8;
     static const uint8_t kSubZeroSpinThrottle  = 9;
     static const uint8_t kSubZeroSpinTolerance = 10;
+
+    static const uint8_t kEntryLength = kSubZeroSpinTolerance + 1;
+    ClientEntryAbstract* entry_array[kEntryLength] = {
+        &mode_,                // 0
+        &raw_value_,           // 1
+        nullptr,               // 2
+        &sign_,                // 3
+        &volts_max_,           // 4
+        &velocity_max_,        // 5
+        &thrust_max_,          // 6
+        &safe_factor_,         // 7
+        &flip_negative_,       // 8
+        &zero_spin_throttle_,  // 9
+        &zero_spin_tolerance_  // 10
+    };
 };
 
 #endif /* ESC_PROPELLER_INPUT_PARSER_CLIENT_HPP_ */

--- a/inc/esc_propeller_input_parser_client.hpp
+++ b/inc/esc_propeller_input_parser_client.hpp
@@ -55,7 +55,9 @@ class EscPropellerInputParserClient : public ClientAbstract {
    }
 
   void GetClientEntryList(ClientEntryAbstract ** client_entries){
-    ClientEntryAbstract* entry_array[GetNumberOfClientEntries()] = {
+    uint16_t num_entries = GetNumberOfClientEntries();
+
+    ClientEntryAbstract* entry_array[num_entries] = {
         &mode_,                // 0
         &raw_value_,           // 1
         nullptr,               // 2
@@ -69,7 +71,7 @@ class EscPropellerInputParserClient : public ClientAbstract {
         &zero_spin_tolerance_  // 10
     };
 
-    for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
+    for(uint16_t entry = 0; entry < num_entries; entry++){
 	    client_entries[entry] = entry_array[entry];
     }
   }

--- a/inc/gpio_controller_client.hpp
+++ b/inc/gpio_controller_client.hpp
@@ -49,23 +49,29 @@ class GpioControllerClient : public ClientAbstract {
     ClientEntry<uint8_t> addressable_pull_type_;             // 9
     ClientEntry<uint8_t> addressable_push_pull_open_drain_;  // 10
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubAddressablePushPullOpenDrain + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &mode_register_,                    // 0
-            &inputs_register_,                  // 1
-            &outputs_register_,                 // 2
-            &use_pull_register_,                // 3
-            &pull_type_register_,               // 4
-            &push_pull_open_drain_register_,    // 5
-            &addressable_gpio_mode_,            // 6
-            &addressable_outputs_,              // 7
-            &addressable_use_pull_,             // 8
-            &addressable_pull_type_,            // 9
-            &addressable_push_pull_open_drain_  // 10
-        };
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubAddressablePushPullOpenDrain + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &mode_register_,                    // 0
+    //         &inputs_register_,                  // 1
+    //         &outputs_register_,                 // 2
+    //         &use_pull_register_,                // 3
+    //         &pull_type_register_,               // 4
+    //         &push_pull_open_drain_register_,    // 5
+    //         &addressable_gpio_mode_,            // 6
+    //         &addressable_outputs_,              // 7
+    //         &addressable_use_pull_,             // 8
+    //         &addressable_pull_type_,            // 9
+    //         &addressable_push_pull_open_drain_  // 10
+    //     };
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubAddressablePushPullOpenDrain + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubModeRegister                 = 0;

--- a/inc/gpio_controller_client.hpp
+++ b/inc/gpio_controller_client.hpp
@@ -49,29 +49,31 @@ class GpioControllerClient : public ClientAbstract {
     ClientEntry<uint8_t> addressable_pull_type_;             // 9
     ClientEntry<uint8_t> addressable_push_pull_open_drain_;  // 10
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubAddressablePushPullOpenDrain + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &mode_register_,                    // 0
-    //         &inputs_register_,                  // 1
-    //         &outputs_register_,                 // 2
-    //         &use_pull_register_,                // 3
-    //         &pull_type_register_,               // 4
-    //         &push_pull_open_drain_register_,    // 5
-    //         &addressable_gpio_mode_,            // 6
-    //         &addressable_outputs_,              // 7
-    //         &addressable_use_pull_,             // 8
-    //         &addressable_pull_type_,            // 9
-    //         &addressable_push_pull_open_drain_  // 10
-    //     };
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    uint16_t GetNumberOfClientEntries(){
+      return kSubAddressablePushPullOpenDrain + 1;
+    }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubAddressablePushPullOpenDrain + 1;
-   }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &mode_register_,                    // 0
+        &inputs_register_,                  // 1
+        &outputs_register_,                 // 2
+        &use_pull_register_,                // 3
+        &pull_type_register_,               // 4
+        &push_pull_open_drain_register_,    // 5
+        &addressable_gpio_mode_,            // 6
+        &addressable_outputs_,              // 7
+        &addressable_use_pull_,             // 8
+        &addressable_pull_type_,            // 9
+        &addressable_push_pull_open_drain_  // 10
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubModeRegister                 = 0;

--- a/inc/hobby_input_client.hpp
+++ b/inc/hobby_input_client.hpp
@@ -41,26 +41,26 @@ class HobbyInputClient: public ClientAbstract{
     ClientEntry<uint32_t>   calibrated_low_ticks_us_;
     ClientEntryVoid         reset_calibration_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubResetCalibration+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &allowed_protocols_,        // 0
-    //     &protocol_,                 // 1
-    //     &calibrated_protocol_,      // 2
-    //     &calibrated_high_ticks_us_, // 3
-    //     &calibrated_low_ticks_us_,  // 4
-    //     &reset_calibration_         // 5
-    //   };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubResetCalibration + 1;
+    }
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubResetCalibration + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &allowed_protocols_,        // 0
+        &protocol_,                 // 1
+        &calibrated_protocol_,      // 2
+        &calibrated_high_ticks_us_, // 3
+        &calibrated_low_ticks_us_,  // 4
+        &reset_calibration_         // 5
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubAllowedProtocols       =  0;

--- a/inc/hobby_input_client.hpp
+++ b/inc/hobby_input_client.hpp
@@ -41,20 +41,26 @@ class HobbyInputClient: public ClientAbstract{
     ClientEntry<uint32_t>   calibrated_low_ticks_us_;
     ClientEntryVoid         reset_calibration_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubResetCalibration+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &allowed_protocols_,        // 0
-        &protocol_,                 // 1
-        &calibrated_protocol_,      // 2
-        &calibrated_high_ticks_us_, // 3
-        &calibrated_low_ticks_us_,  // 4
-        &reset_calibration_         // 5
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubResetCalibration+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &allowed_protocols_,        // 0
+    //     &protocol_,                 // 1
+    //     &calibrated_protocol_,      // 2
+    //     &calibrated_high_ticks_us_, // 3
+    //     &calibrated_low_ticks_us_,  // 4
+    //     &reset_calibration_         // 5
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubResetCalibration + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubAllowedProtocols       =  0;

--- a/inc/iquart_flight_controller_interface_client.hpp
+++ b/inc/iquart_flight_controller_interface_client.hpp
@@ -54,7 +54,11 @@ class IQUartFlightControllerInterfaceClient : public ClientAbstract {
           telemetry_(kTypeIQUartFlightControllerInterface, obj_idn, kSubTelemetry),
           throttle_cvi_(kTypeIQUartFlightControllerInterface, obj_idn, kSubThrottleCvi),
           x_cvi_(kTypeIQUartFlightControllerInterface, obj_idn, kSubXCvi),
-          y_cvi_(kTypeIQUartFlightControllerInterface, obj_idn, kSubYCvi){};
+          y_cvi_(kTypeIQUartFlightControllerInterface, obj_idn, kSubYCvi)
+          {
+            entry_array_head = entry_array;
+            num_entries = kEntryLength;
+          };
 
     // Client Entries
     PackedClientEntry packed_command_;
@@ -64,31 +68,8 @@ class IQUartFlightControllerInterfaceClient : public ClientAbstract {
     ClientEntry<uint8_t> y_cvi_;
 
     void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubYCvi + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &packed_command_, // 0
-            &telemetry_,     // 1
-            &throttle_cvi_,  // 2
-            &x_cvi_,         // 3
-            &y_cvi_          // 4
-        };
         ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
     }
-
-
-    void UpdateEntryIds(uint8_t new_id){
-        static const uint8_t kEntryLength = kSubYCvi + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &packed_command_, // 0
-            &telemetry_,     // 1
-            &throttle_cvi_,  // 2
-            &x_cvi_,         // 3
-            &y_cvi_          // 4
-        };
-
-        UpdateEntryIdsFromList(entry_array, kEntryLength, new_id);
-    }
-
 
     /**
      * @brief This function takes in an IFCIPackedMessage struct, and prepares the data as a series of bytes ready for transmission over IQUART
@@ -117,6 +98,15 @@ class IQUartFlightControllerInterfaceClient : public ClientAbstract {
     static const uint8_t kSubThrottleCvi     = 2;
     static const uint8_t kSubXCvi            = 3;
     static const uint8_t kSubYCvi            = 4;
+
+    static const uint8_t kEntryLength = kSubYCvi + 1;
+    ClientEntryAbstract* entry_array[kEntryLength] = {
+        &packed_command_, // 0
+        &telemetry_,     // 1
+        &throttle_cvi_,  // 2
+        &x_cvi_,         // 3
+        &y_cvi_          // 4
+    };
 };
 
 #endif /* IQUART_FLIGHT_CONTROLLER_INTERFACE_CLIENT_HPP_ */

--- a/inc/iquart_flight_controller_interface_client.hpp
+++ b/inc/iquart_flight_controller_interface_client.hpp
@@ -86,23 +86,26 @@ class IQUartFlightControllerInterfaceClient : public ClientAbstract {
       *output_data_length = ifci_commands->num_cvs * 2 + 1;
     }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubYCvi + 1;
-   }
-
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){
-    ClientEntryAbstract* entry_array[GetNumberOfClientEntries()] = {
-      &packed_command_, // 0
-      &telemetry_,     // 1
-      &throttle_cvi_,  // 2
-      &x_cvi_,         // 3
-      &y_cvi_          // 4
-    };
-
-    for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
-      client_entries[entry] = entry_array[entry];
+    uint16_t GetNumberOfClientEntries(){
+      return kSubYCvi + 1;
     }
-  }
+
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+
+      uint16_t num_entries = GetNumberOfClientEntries();
+
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &packed_command_, // 0
+        &telemetry_,     // 1
+        &throttle_cvi_,  // 2
+        &x_cvi_,         // 3
+        &y_cvi_          // 4
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubPackedCommand   = 0;

--- a/inc/iquart_flight_controller_interface_client.hpp
+++ b/inc/iquart_flight_controller_interface_client.hpp
@@ -24,7 +24,7 @@ const uint8_t kTypeIQUartFlightControllerInterface = 88;
 
 /**
  * @brief A struct that holds the data from a received telemetry packet
- * 
+ *
  */
 struct __attribute__ ((__packed__)) IFCITelemetryData{
     int16_t mcu_temp;  //centi ℃
@@ -38,9 +38,9 @@ struct __attribute__ ((__packed__)) IFCITelemetryData{
 
 /**
  * @brief A struct that can be used to more easily send an IFCI packed command message
- * 
+ *
  */
-struct __attribute__ ((__packed__)) IFCIPackedMessage{ 
+struct __attribute__ ((__packed__)) IFCIPackedMessage{
   uint16_t commands[MAX_CONTROL_VALUES_PER_IFCI]; //An array to hold all control values
   uint8_t telem_byte; //The module ID to send back its telemetry
   uint8_t num_cvs;  //The number of control values being sent in this command
@@ -75,17 +75,32 @@ class IQUartFlightControllerInterfaceClient : public ClientAbstract {
         ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
     }
 
+
+    void UpdateEntryIds(uint8_t new_id){
+        static const uint8_t kEntryLength = kSubYCvi + 1;
+        ClientEntryAbstract* entry_array[kEntryLength] = {
+            &packed_command_, // 0
+            &telemetry_,     // 1
+            &throttle_cvi_,  // 2
+            &x_cvi_,         // 3
+            &y_cvi_          // 4
+        };
+
+        UpdateEntryIdsFromList(entry_array, kEntryLength, new_id);
+    }
+
+
     /**
      * @brief This function takes in an IFCIPackedMessage struct, and prepares the data as a series of bytes ready for transmission over IQUART
      * As an example, assume you want to send 4 throttle commands, and get telemetry from Module ID 3. To do so, make an IFCIPackedMessage and set
      * commands[0] through commands[3] to throttle values [0, 65535], telem_byte to 3, and num_cvs to 4. Then, create a byte array, and a byte to store the
      * message length, and call this function.
-     * 
+     *
      * @param ifci_commands The IFCIPackedMessage struct that you want to send
      * @param output_data A pointer to an array of bytes that will store the data
      * @param output_data_length The length of the data stored in the output_data array
      */
-    void PackageIfciCommandsForTransmission(IFCIPackedMessage * ifci_commands, uint8_t * output_data, uint8_t * output_data_length){      
+    void PackageIfciCommandsForTransmission(IFCIPackedMessage * ifci_commands, uint8_t * output_data, uint8_t * output_data_length){
       //Copy the CV bytes
       memcpy(output_data, ifci_commands->commands, ifci_commands->num_cvs * 2);
 

--- a/inc/iquart_flight_controller_interface_client.hpp
+++ b/inc/iquart_flight_controller_interface_client.hpp
@@ -56,8 +56,6 @@ class IQUartFlightControllerInterfaceClient : public ClientAbstract {
           x_cvi_(kTypeIQUartFlightControllerInterface, obj_idn, kSubXCvi),
           y_cvi_(kTypeIQUartFlightControllerInterface, obj_idn, kSubYCvi)
           {
-            entry_array_head = entry_array;
-            num_entries = kEntryLength;
           };
 
     // Client Entries
@@ -66,10 +64,6 @@ class IQUartFlightControllerInterfaceClient : public ClientAbstract {
     ClientEntry<uint8_t> throttle_cvi_;
     ClientEntry<uint8_t> x_cvi_;
     ClientEntry<uint8_t> y_cvi_;
-
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
 
     /**
      * @brief This function takes in an IFCIPackedMessage struct, and prepares the data as a series of bytes ready for transmission over IQUART
@@ -92,21 +86,30 @@ class IQUartFlightControllerInterfaceClient : public ClientAbstract {
       *output_data_length = ifci_commands->num_cvs * 2 + 1;
     }
 
+   uint16_t GetNumberOfClientEntries(){
+	return kSubYCvi + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){
+    ClientEntryAbstract* entry_array[GetNumberOfClientEntries()] = {
+      &packed_command_, // 0
+      &telemetry_,     // 1
+      &throttle_cvi_,  // 2
+      &x_cvi_,         // 3
+      &y_cvi_          // 4
+    };
+
+    for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
+      client_entries[entry] = entry_array[entry];
+    }
+  }
+
    private:
     static const uint8_t kSubPackedCommand   = 0;
     static const uint8_t kSubTelemetry       = 1;
     static const uint8_t kSubThrottleCvi     = 2;
     static const uint8_t kSubXCvi            = 3;
     static const uint8_t kSubYCvi            = 4;
-
-    static const uint8_t kEntryLength = kSubYCvi + 1;
-    ClientEntryAbstract* entry_array[kEntryLength] = {
-        &packed_command_, // 0
-        &telemetry_,     // 1
-        &throttle_cvi_,  // 2
-        &x_cvi_,         // 3
-        &y_cvi_          // 4
-    };
 };
 
 #endif /* IQUART_FLIGHT_CONTROLLER_INTERFACE_CLIENT_HPP_ */

--- a/inc/mag_alpha_client.hpp
+++ b/inc/mag_alpha_client.hpp
@@ -8,9 +8,9 @@
 
 /*
   Name: mag_alpha_client.hpp
-  Last update: 2023/06/29 by Ben Quan 
-  Author: Ben Quan 
-  Contributors: 
+  Last update: 2023/06/29 by Ben Quan
+  Author: Ben Quan
+  Contributors:
 */
 
 #ifndef MAG_ALPHA_CLIENT_HPP
@@ -40,26 +40,32 @@ class MagAlphaClient: public ClientAbstract{
     ClientEntry<uint8_t>     alarm_;
     ClientEntry<uint8_t>     mght_;
     ClientEntry<uint8_t>     mglt_;
-    ClientEntry<uint16_t>    reg_val_;  
+    ClientEntry<uint16_t>    reg_val_;
     ClientEntry<uint16_t>    reg_adr_;
-    ClientEntryVoid          reg_str_;         
+    ClientEntryVoid          reg_str_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubRegStr+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &angle_raw_,    // 0
-        &angle_rad_,    // 1
-        &alarm_,        // 2
-        &mght_,         // 3
-        &mglt_,         // 4
-        &reg_val_,      // 5
-        &reg_adr_,      // 6
-        &reg_str_       // 7
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubRegStr+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &angle_raw_,    // 0
+    //     &angle_rad_,    // 1
+    //     &alarm_,        // 2
+    //     &mght_,         // 3
+    //     &mglt_,         // 4
+    //     &reg_val_,      // 5
+    //     &reg_adr_,      // 6
+    //     &reg_str_       // 7
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubRegStr + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubAngleRaw    = 0;

--- a/inc/mag_alpha_client.hpp
+++ b/inc/mag_alpha_client.hpp
@@ -44,28 +44,29 @@ class MagAlphaClient: public ClientAbstract{
     ClientEntry<uint16_t>    reg_adr_;
     ClientEntryVoid          reg_str_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubRegStr+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &angle_raw_,    // 0
-    //     &angle_rad_,    // 1
-    //     &alarm_,        // 2
-    //     &mght_,         // 3
-    //     &mglt_,         // 4
-    //     &reg_val_,      // 5
-    //     &reg_adr_,      // 6
-    //     &reg_str_       // 7
-    //   };
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    uint16_t GetNumberOfClientEntries(){
+      return kSubRegStr + 1;
+    }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubRegStr + 1;
-   }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &angle_raw_,    // 0
+        &angle_rad_,    // 1
+        &alarm_,        // 2
+        &mght_,         // 3
+        &mglt_,         // 4
+        &reg_val_,      // 5
+        &reg_adr_,      // 6
+        &reg_str_       // 7
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubAngleRaw    = 0;

--- a/inc/multi_turn_angle_control_client.hpp
+++ b/inc/multi_turn_angle_control_client.hpp
@@ -98,45 +98,51 @@ class MultiTurnAngleControlClient : public ClientAbstract {
     ClientEntryVoid sample_zero_angle_;
     ClientEntry<float> zero_angle_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubZeroAngle + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &ctrl_mode_,                        // 0
-            &ctrl_brake_,                       // 1
-            &ctrl_coast_,                       // 2
-            &ctrl_angle_,                       // 3
-            &ctrl_velocity_,                    // 4
-            &angle_Kp_,                         // 5
-            &angle_Ki_,                         // 6
-            &angle_Kd_,                         // 7
-            &timeout_,                          // 8
-            &ctrl_pwm_,                         // 9
-            &ctrl_volts_,                       // 10
-            &obs_angular_displacement_,         // 11
-            &obs_angular_velocity_,             // 12
-            &meter_per_rad_,                    // 13
-            &ctrl_linear_displacement_,         // 14
-            &ctrl_linear_velocity_,             // 15
-            &obs_linear_displacement_,          // 16
-            &obs_linear_velocity_,              // 17
-            &angular_speed_max_,                // 18
-            &trajectory_angular_displacement_,  // 19
-            &trajectory_angular_velocity_,      // 20
-            &trajectory_angular_acceleration_,  // 21
-            &trajectory_duration_,              // 22
-            &trajectory_linear_displacement_,   // 23
-            &trajectory_linear_velocity_,       // 24
-            &trajectory_linear_acceleration_,   // 25
-            &trajectory_average_speed_,         // 26
-            &trajectory_queue_mode_,            // 27
-            nullptr,                            // 28
-            &ff_,                               // 29
-            &sample_zero_angle_,                // 30
-            &zero_angle_                        // 31
-        };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubZeroAngle + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &ctrl_mode_,                        // 0
+    //         &ctrl_brake_,                       // 1
+    //         &ctrl_coast_,                       // 2
+    //         &ctrl_angle_,                       // 3
+    //         &ctrl_velocity_,                    // 4
+    //         &angle_Kp_,                         // 5
+    //         &angle_Ki_,                         // 6
+    //         &angle_Kd_,                         // 7
+    //         &timeout_,                          // 8
+    //         &ctrl_pwm_,                         // 9
+    //         &ctrl_volts_,                       // 10
+    //         &obs_angular_displacement_,         // 11
+    //         &obs_angular_velocity_,             // 12
+    //         &meter_per_rad_,                    // 13
+    //         &ctrl_linear_displacement_,         // 14
+    //         &ctrl_linear_velocity_,             // 15
+    //         &obs_linear_displacement_,          // 16
+    //         &obs_linear_velocity_,              // 17
+    //         &angular_speed_max_,                // 18
+    //         &trajectory_angular_displacement_,  // 19
+    //         &trajectory_angular_velocity_,      // 20
+    //         &trajectory_angular_acceleration_,  // 21
+    //         &trajectory_duration_,              // 22
+    //         &trajectory_linear_displacement_,   // 23
+    //         &trajectory_linear_velocity_,       // 24
+    //         &trajectory_linear_acceleration_,   // 25
+    //         &trajectory_average_speed_,         // 26
+    //         &trajectory_queue_mode_,            // 27
+    //         nullptr,                            // 28
+    //         &ff_,                               // 29
+    //         &sample_zero_angle_,                // 30
+    //         &zero_angle_                        // 31
+    //     };
 
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubZeroAngle + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubCtrlMode                      = 0;

--- a/inc/multi_turn_angle_control_client.hpp
+++ b/inc/multi_turn_angle_control_client.hpp
@@ -98,51 +98,52 @@ class MultiTurnAngleControlClient : public ClientAbstract {
     ClientEntryVoid sample_zero_angle_;
     ClientEntry<float> zero_angle_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubZeroAngle + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &ctrl_mode_,                        // 0
-    //         &ctrl_brake_,                       // 1
-    //         &ctrl_coast_,                       // 2
-    //         &ctrl_angle_,                       // 3
-    //         &ctrl_velocity_,                    // 4
-    //         &angle_Kp_,                         // 5
-    //         &angle_Ki_,                         // 6
-    //         &angle_Kd_,                         // 7
-    //         &timeout_,                          // 8
-    //         &ctrl_pwm_,                         // 9
-    //         &ctrl_volts_,                       // 10
-    //         &obs_angular_displacement_,         // 11
-    //         &obs_angular_velocity_,             // 12
-    //         &meter_per_rad_,                    // 13
-    //         &ctrl_linear_displacement_,         // 14
-    //         &ctrl_linear_velocity_,             // 15
-    //         &obs_linear_displacement_,          // 16
-    //         &obs_linear_velocity_,              // 17
-    //         &angular_speed_max_,                // 18
-    //         &trajectory_angular_displacement_,  // 19
-    //         &trajectory_angular_velocity_,      // 20
-    //         &trajectory_angular_acceleration_,  // 21
-    //         &trajectory_duration_,              // 22
-    //         &trajectory_linear_displacement_,   // 23
-    //         &trajectory_linear_velocity_,       // 24
-    //         &trajectory_linear_acceleration_,   // 25
-    //         &trajectory_average_speed_,         // 26
-    //         &trajectory_queue_mode_,            // 27
-    //         nullptr,                            // 28
-    //         &ff_,                               // 29
-    //         &sample_zero_angle_,                // 30
-    //         &zero_angle_                        // 31
-    //     };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubZeroAngle + 1;
+    }
 
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubZeroAngle + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &ctrl_mode_,                        // 0
+        &ctrl_brake_,                       // 1
+        &ctrl_coast_,                       // 2
+        &ctrl_angle_,                       // 3
+        &ctrl_velocity_,                    // 4
+        &angle_Kp_,                         // 5
+        &angle_Ki_,                         // 6
+        &angle_Kd_,                         // 7
+        &timeout_,                          // 8
+        &ctrl_pwm_,                         // 9
+        &ctrl_volts_,                       // 10
+        &obs_angular_displacement_,         // 11
+        &obs_angular_velocity_,             // 12
+        &meter_per_rad_,                    // 13
+        &ctrl_linear_displacement_,         // 14
+        &ctrl_linear_velocity_,             // 15
+        &obs_linear_displacement_,          // 16
+        &obs_linear_velocity_,              // 17
+        &angular_speed_max_,                // 18
+        &trajectory_angular_displacement_,  // 19
+        &trajectory_angular_velocity_,      // 20
+        &trajectory_angular_acceleration_,  // 21
+        &trajectory_duration_,              // 22
+        &trajectory_linear_displacement_,   // 23
+        &trajectory_linear_velocity_,       // 24
+        &trajectory_linear_acceleration_,   // 25
+        &trajectory_average_speed_,         // 26
+        &trajectory_queue_mode_,            // 27
+        nullptr,                            // 28
+        &ff_,                               // 29
+        &sample_zero_angle_,                // 30
+        &zero_angle_                        // 31
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubCtrlMode                      = 0;

--- a/inc/persistent_memory_client.hpp
+++ b/inc/persistent_memory_client.hpp
@@ -37,25 +37,24 @@ class PersistentMemoryClient: public ClientAbstract{
     ClientEntry<uint32_t>  format_key_1_;
     ClientEntry<uint32_t>  format_key_2_;
 
+    uint16_t GetNumberOfClientEntries(){
+      return kSubFormatKey2 + 1;
+    }
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubFormatKey2+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &erase_,             // 0
-    //     &revert_to_default_, // 1
-    //     &format_key_1_,      // 2
-    //     &format_key_2_       // 3
-    //   };
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &erase_,             // 0
+        &revert_to_default_, // 1
+        &format_key_1_,      // 2
+        &format_key_2_       // 3
+      };
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubFormatKey2 + 1;
-   }
-
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubErase            = 0;

--- a/inc/persistent_memory_client.hpp
+++ b/inc/persistent_memory_client.hpp
@@ -8,7 +8,7 @@
 
 /*
   Name: persistent_memory_client.hpp
-  Last update: 10/31/2022 by Ben Quan 
+  Last update: 10/31/2022 by Ben Quan
   Author: Matthew Piccoli
   Contributors: Ben Quan, Raphael Van Hoffelen
 */
@@ -38,18 +38,24 @@ class PersistentMemoryClient: public ClientAbstract{
     ClientEntry<uint32_t>  format_key_2_;
 
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubFormatKey2+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &erase_,             // 0
-        &revert_to_default_, // 1
-        &format_key_1_,      // 2
-        &format_key_2_       // 3
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubFormatKey2+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &erase_,             // 0
+    //     &revert_to_default_, // 1
+    //     &format_key_1_,      // 2
+    //     &format_key_2_       // 3
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubFormatKey2 + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubErase            = 0;

--- a/inc/power_monitor_client.hpp
+++ b/inc/power_monitor_client.hpp
@@ -53,26 +53,32 @@ class PowerMonitorClient: public ClientAbstract{
     ClientEntry<float>      amps_gain_;
     ClientEntry<float>      amps_bias_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubAmpsBias+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &volts_,        // 0
-        &amps_,         // 1
-        &watts_,        // 2
-        &joules_,       // 3
-        &reset_joules_, // 4
-        &filter_fs_,    // 5
-        &filter_fc_,    // 6
-        &volts_raw_,    // 7
-        &amps_raw_,     // 8
-        &volts_gain_,   // 9
-        &amps_gain_,    // 10
-        &amps_bias_    // 11
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubAmpsBias+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &volts_,        // 0
+    //     &amps_,         // 1
+    //     &watts_,        // 2
+    //     &joules_,       // 3
+    //     &reset_joules_, // 4
+    //     &filter_fs_,    // 5
+    //     &filter_fc_,    // 6
+    //     &volts_raw_,    // 7
+    //     &amps_raw_,     // 8
+    //     &volts_gain_,   // 9
+    //     &amps_gain_,    // 10
+    //     &amps_bias_    // 11
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubAmpsBias + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubVolts        =  0;

--- a/inc/power_monitor_client.hpp
+++ b/inc/power_monitor_client.hpp
@@ -53,32 +53,32 @@ class PowerMonitorClient: public ClientAbstract{
     ClientEntry<float>      amps_gain_;
     ClientEntry<float>      amps_bias_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubAmpsBias+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &volts_,        // 0
-    //     &amps_,         // 1
-    //     &watts_,        // 2
-    //     &joules_,       // 3
-    //     &reset_joules_, // 4
-    //     &filter_fs_,    // 5
-    //     &filter_fc_,    // 6
-    //     &volts_raw_,    // 7
-    //     &amps_raw_,     // 8
-    //     &volts_gain_,   // 9
-    //     &amps_gain_,    // 10
-    //     &amps_bias_    // 11
-    //   };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubAmpsBias + 1;
+    }
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubAmpsBias + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &volts_,        // 0
+        &amps_,         // 1
+        &watts_,        // 2
+        &joules_,       // 3
+        &reset_joules_, // 4
+        &filter_fs_,    // 5
+        &filter_fc_,    // 6
+        &volts_raw_,    // 7
+        &amps_raw_,     // 8
+        &volts_gain_,   // 9
+        &amps_gain_,    // 10
+        &amps_bias_    // 11
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubVolts        =  0;

--- a/inc/power_safety_client.hpp
+++ b/inc/power_safety_client.hpp
@@ -57,33 +57,35 @@ class PowerSafetyClient : public ClientAbstract {
     ClientEntry<float> temperature_coil_low_;
     ClientEntry<float> temperature_coil_high_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubTemperatureCoilHigh + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &fault_now_,              // 0
-    //         &fault_ever_,             // 1
-    //         &fault_latching_,         // 2
-    //         &volt_input_low_,         // 3
-    //         &volt_input_high_,        // 4
-    //         &vref_int_low_,           // 5
-    //         &vref_int_high_,          // 6
-    //         &current_input_low_,      // 7
-    //         &current_input_high_,     // 8
-    //         &motor_current_low_,      // 9
-    //         &motor_current_high_,     // 10
-    //         &temperature_uc_low_,     // 11
-    //         &temperature_uc_high_,    // 12
-    //         &temperature_coil_low_,   // 13
-    //         &temperature_coil_high_,  // 14
-    //     };
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    uint16_t GetNumberOfClientEntries(){
+      return kSubTemperatureCoilHigh + 1;
+    }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubTemperatureCoilHigh + 1;
-   }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &fault_now_,              // 0
+        &fault_ever_,             // 1
+        &fault_latching_,         // 2
+        &volt_input_low_,         // 3
+        &volt_input_high_,        // 4
+        &vref_int_low_,           // 5
+        &vref_int_high_,          // 6
+        &current_input_low_,      // 7
+        &current_input_high_,     // 8
+        &motor_current_low_,      // 9
+        &motor_current_high_,     // 10
+        &temperature_uc_low_,     // 11
+        &temperature_uc_high_,    // 12
+        &temperature_coil_low_,   // 13
+        &temperature_coil_high_,  // 14
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubFaultNow            = 0;

--- a/inc/power_safety_client.hpp
+++ b/inc/power_safety_client.hpp
@@ -57,27 +57,33 @@ class PowerSafetyClient : public ClientAbstract {
     ClientEntry<float> temperature_coil_low_;
     ClientEntry<float> temperature_coil_high_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubTemperatureCoilHigh + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &fault_now_,              // 0
-            &fault_ever_,             // 1
-            &fault_latching_,         // 2
-            &volt_input_low_,         // 3
-            &volt_input_high_,        // 4
-            &vref_int_low_,           // 5
-            &vref_int_high_,          // 6
-            &current_input_low_,      // 7
-            &current_input_high_,     // 8
-            &motor_current_low_,      // 9
-            &motor_current_high_,     // 10
-            &temperature_uc_low_,     // 11
-            &temperature_uc_high_,    // 12
-            &temperature_coil_low_,   // 13
-            &temperature_coil_high_,  // 14
-        };
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubTemperatureCoilHigh + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &fault_now_,              // 0
+    //         &fault_ever_,             // 1
+    //         &fault_latching_,         // 2
+    //         &volt_input_low_,         // 3
+    //         &volt_input_high_,        // 4
+    //         &vref_int_low_,           // 5
+    //         &vref_int_high_,          // 6
+    //         &current_input_low_,      // 7
+    //         &current_input_high_,     // 8
+    //         &motor_current_low_,      // 9
+    //         &motor_current_high_,     // 10
+    //         &temperature_uc_low_,     // 11
+    //         &temperature_uc_high_,    // 12
+    //         &temperature_coil_low_,   // 13
+    //         &temperature_coil_high_,  // 14
+    //     };
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubTemperatureCoilHigh + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubFaultNow            = 0;

--- a/inc/propeller_motor_control_client.hpp
+++ b/inc/propeller_motor_control_client.hpp
@@ -72,33 +72,68 @@ class PropellerMotorControlClient : public ClientAbstract {
     ClientEntry<uint8_t> timeout_behavior_;
     ClientEntry<uint8_t> timeout_song_option_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubTimeoutSongOption + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &ctrl_mode_,           // 0
-            &ctrl_brake_,          // 1
-            &ctrl_coast_,          // 2
-            &ctrl_pwm_,            // 3
-            &ctrl_volts_,          // 4
-            &ctrl_velocity_,       // 5
-            &ctrl_thrust_,         // 6
-            &velocity_kp_,         // 7
-            &velocity_ki_,         // 8
-            &velocity_kd_,         // 9
-            &velocity_ff0_,        // 10
-            &velocity_ff1_,        // 11
-            &velocity_ff2_,        // 12
-            &propeller_kt_pos_,    // 13
-            &propeller_kt_neg_,    // 14
-            &timeout_,             // 15
-            &input_filter_fc_,     // 16
-            &timeout_meaning_,     // 17
-            &timeout_behavior_,    // 18
-            &timeout_song_option_  // 19
-        };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubTimeoutSongOption + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &ctrl_mode_,           // 0
+    //         &ctrl_brake_,          // 1
+    //         &ctrl_coast_,          // 2
+    //         &ctrl_pwm_,            // 3
+    //         &ctrl_volts_,          // 4
+    //         &ctrl_velocity_,       // 5
+    //         &ctrl_thrust_,         // 6
+    //         &velocity_kp_,         // 7
+    //         &velocity_ki_,         // 8
+    //         &velocity_kd_,         // 9
+    //         &velocity_ff0_,        // 10
+    //         &velocity_ff1_,        // 11
+    //         &velocity_ff2_,        // 12
+    //         &propeller_kt_pos_,    // 13
+    //         &propeller_kt_neg_,    // 14
+    //         &timeout_,             // 15
+    //         &input_filter_fc_,     // 16
+    //         &timeout_meaning_,     // 17
+    //         &timeout_behavior_,    // 18
+    //         &timeout_song_option_  // 19
+    //     };
 
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubTimeoutSongOption + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){
+    ClientEntryAbstract* entry_array[GetNumberOfClientEntries()] = {
+        &ctrl_mode_,           // 0
+        &ctrl_brake_,          // 1
+        &ctrl_coast_,          // 2
+        &ctrl_pwm_,            // 3
+        &ctrl_volts_,          // 4
+        &ctrl_velocity_,       // 5
+        &ctrl_thrust_,         // 6
+        &velocity_kp_,         // 7
+        &velocity_ki_,         // 8
+        &velocity_kd_,         // 9
+        &velocity_ff0_,        // 10
+        &velocity_ff1_,        // 11
+        &velocity_ff2_,        // 12
+        &propeller_kt_pos_,    // 13
+        &propeller_kt_neg_,    // 14
+        &timeout_,             // 15
+        &input_filter_fc_,     // 16
+        &timeout_meaning_,     // 17
+        &timeout_behavior_,    // 18
+        &timeout_song_option_  // 19
+    };
+
+    for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
+      client_entries[entry] = entry_array[entry];
     }
+
+  }
+
 
    private:
     static const uint8_t kSubCtrlMode          = 0;

--- a/inc/propeller_motor_control_client.hpp
+++ b/inc/propeller_motor_control_client.hpp
@@ -72,68 +72,40 @@ class PropellerMotorControlClient : public ClientAbstract {
     ClientEntry<uint8_t> timeout_behavior_;
     ClientEntry<uint8_t> timeout_song_option_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubTimeoutSongOption + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &ctrl_mode_,           // 0
-    //         &ctrl_brake_,          // 1
-    //         &ctrl_coast_,          // 2
-    //         &ctrl_pwm_,            // 3
-    //         &ctrl_volts_,          // 4
-    //         &ctrl_velocity_,       // 5
-    //         &ctrl_thrust_,         // 6
-    //         &velocity_kp_,         // 7
-    //         &velocity_ki_,         // 8
-    //         &velocity_kd_,         // 9
-    //         &velocity_ff0_,        // 10
-    //         &velocity_ff1_,        // 11
-    //         &velocity_ff2_,        // 12
-    //         &propeller_kt_pos_,    // 13
-    //         &propeller_kt_neg_,    // 14
-    //         &timeout_,             // 15
-    //         &input_filter_fc_,     // 16
-    //         &timeout_meaning_,     // 17
-    //         &timeout_behavior_,    // 18
-    //         &timeout_song_option_  // 19
-    //     };
-
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
-
-   uint16_t GetNumberOfClientEntries(){
-	return kSubTimeoutSongOption + 1;
-   }
-
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){
-    ClientEntryAbstract* entry_array[GetNumberOfClientEntries()] = {
-        &ctrl_mode_,           // 0
-        &ctrl_brake_,          // 1
-        &ctrl_coast_,          // 2
-        &ctrl_pwm_,            // 3
-        &ctrl_volts_,          // 4
-        &ctrl_velocity_,       // 5
-        &ctrl_thrust_,         // 6
-        &velocity_kp_,         // 7
-        &velocity_ki_,         // 8
-        &velocity_kd_,         // 9
-        &velocity_ff0_,        // 10
-        &velocity_ff1_,        // 11
-        &velocity_ff2_,        // 12
-        &propeller_kt_pos_,    // 13
-        &propeller_kt_neg_,    // 14
-        &timeout_,             // 15
-        &input_filter_fc_,     // 16
-        &timeout_meaning_,     // 17
-        &timeout_behavior_,    // 18
-        &timeout_song_option_  // 19
-    };
-
-    for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
-      client_entries[entry] = entry_array[entry];
+    uint16_t GetNumberOfClientEntries(){
+      return kSubTimeoutSongOption + 1;
     }
 
-  }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
+      ClientEntryAbstract* entry_array[num_entries] = {
+          &ctrl_mode_,           // 0
+          &ctrl_brake_,          // 1
+          &ctrl_coast_,          // 2
+          &ctrl_pwm_,            // 3
+          &ctrl_volts_,          // 4
+          &ctrl_velocity_,       // 5
+          &ctrl_thrust_,         // 6
+          &velocity_kp_,         // 7
+          &velocity_ki_,         // 8
+          &velocity_kd_,         // 9
+          &velocity_ff0_,        // 10
+          &velocity_ff1_,        // 11
+          &velocity_ff2_,        // 12
+          &propeller_kt_pos_,    // 13
+          &propeller_kt_neg_,    // 14
+          &timeout_,             // 15
+          &input_filter_fc_,     // 16
+          &timeout_meaning_,     // 17
+          &timeout_behavior_,    // 18
+          &timeout_song_option_  // 19
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubCtrlMode          = 0;

--- a/inc/pulsing_rectangular_input_parser_client.hpp
+++ b/inc/pulsing_rectangular_input_parser_client.hpp
@@ -40,6 +40,16 @@ class PulsingRectangularInputParserClient : public ClientAbstract {
         ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
     }
 
+    void UpdateEntryIds(uint8_t new_id){
+      static const uint8_t kEntryLength = kSubPulsingVoltageLimit + 1;
+      ClientEntryAbstract* entry_array[kEntryLength] = {
+          &pulsing_voltage_mode_,  // 0
+          &pulsing_voltage_limit_  // 1
+      };
+
+      UpdateEntryIdsFromList(entry_array, kEntryLength, new_id);
+    }
+
    private:
     static const uint8_t kSubPulsingVoltageMode  = 0;
     static const uint8_t kSubPulsingVoltageLimit = 1;

--- a/inc/pulsing_rectangular_input_parser_client.hpp
+++ b/inc/pulsing_rectangular_input_parser_client.hpp
@@ -25,34 +25,29 @@ class PulsingRectangularInputParserClient : public ClientAbstract {
     PulsingRectangularInputParserClient(uint8_t obj_idn)
         : ClientAbstract(kTypePulsingRectangularInputParser, obj_idn),
           pulsing_voltage_mode_(kTypePulsingRectangularInputParser, obj_idn, kSubPulsingVoltageMode),
-          pulsing_voltage_limit_(kTypePulsingRectangularInputParser, obj_idn, kSubPulsingVoltageLimit){};
+          pulsing_voltage_limit_(kTypePulsingRectangularInputParser, obj_idn, kSubPulsingVoltageLimit)
+          {
+            entry_array_head = entry_array;
+            num_entries = kEntryLength;
+          };
 
     // Client Entries
     ClientEntry<uint8_t> pulsing_voltage_mode_;
     ClientEntry<float> pulsing_voltage_limit_;
 
     void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubPulsingVoltageLimit + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &pulsing_voltage_mode_,  // 0
-            &pulsing_voltage_limit_  // 1
-        };
         ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
-
-    void UpdateEntryIds(uint8_t new_id){
-      static const uint8_t kEntryLength = kSubPulsingVoltageLimit + 1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-          &pulsing_voltage_mode_,  // 0
-          &pulsing_voltage_limit_  // 1
-      };
-
-      UpdateEntryIdsFromList(entry_array, kEntryLength, new_id);
     }
 
    private:
     static const uint8_t kSubPulsingVoltageMode  = 0;
     static const uint8_t kSubPulsingVoltageLimit = 1;
+
+    static const uint8_t kEntryLength = kSubPulsingVoltageLimit + 1;
+    ClientEntryAbstract* entry_array[kEntryLength] = {
+        &pulsing_voltage_mode_,  // 0
+        &pulsing_voltage_limit_  // 1
+    };
 };
 
 #endif /* PULSING_RECTANGULAR_INPUT_PARSER_CLIENT_HPP_ */

--- a/inc/pulsing_rectangular_input_parser_client.hpp
+++ b/inc/pulsing_rectangular_input_parser_client.hpp
@@ -27,27 +27,30 @@ class PulsingRectangularInputParserClient : public ClientAbstract {
           pulsing_voltage_mode_(kTypePulsingRectangularInputParser, obj_idn, kSubPulsingVoltageMode),
           pulsing_voltage_limit_(kTypePulsingRectangularInputParser, obj_idn, kSubPulsingVoltageLimit)
           {
-            entry_array_head = entry_array;
-            num_entries = kEntryLength;
           };
 
     // Client Entries
     ClientEntry<uint8_t> pulsing_voltage_mode_;
     ClientEntry<float> pulsing_voltage_limit_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+   uint16_t GetNumberOfClientEntries(){
+	return pulsing_voltage_limit_ + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){
+	ClientEntryAbstract* entry_array[GetNumberOfClientEntries()] = {
+		&pulsing_voltage_mode_,  // 0
+        	&pulsing_voltage_limit_  // 1
+	}
+
+    for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
+	client_entries[entry] = entry_array[entry];
     }
+  }
 
    private:
     static const uint8_t kSubPulsingVoltageMode  = 0;
     static const uint8_t kSubPulsingVoltageLimit = 1;
-
-    static const uint8_t kEntryLength = kSubPulsingVoltageLimit + 1;
-    ClientEntryAbstract* entry_array[kEntryLength] = {
-        &pulsing_voltage_mode_,  // 0
-        &pulsing_voltage_limit_  // 1
-    };
 };
 
 #endif /* PULSING_RECTANGULAR_INPUT_PARSER_CLIENT_HPP_ */

--- a/inc/pulsing_rectangular_input_parser_client.hpp
+++ b/inc/pulsing_rectangular_input_parser_client.hpp
@@ -33,20 +33,22 @@ class PulsingRectangularInputParserClient : public ClientAbstract {
     ClientEntry<uint8_t> pulsing_voltage_mode_;
     ClientEntry<float> pulsing_voltage_limit_;
 
-   uint16_t GetNumberOfClientEntries(){
-	return pulsing_voltage_limit_ + 1;
-   }
-
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){
-	ClientEntryAbstract* entry_array[GetNumberOfClientEntries()] = {
-		&pulsing_voltage_mode_,  // 0
-        	&pulsing_voltage_limit_  // 1
-	}
-
-    for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
-	client_entries[entry] = entry_array[entry];
+    uint16_t GetNumberOfClientEntries(){
+      return kSubPulsingVoltageLimit + 1;
     }
-  }
+
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
+
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &pulsing_voltage_mode_,  // 0
+        &pulsing_voltage_limit_  // 1
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubPulsingVoltageMode  = 0;

--- a/inc/pwm_interface_client.hpp
+++ b/inc/pwm_interface_client.hpp
@@ -33,15 +33,21 @@ class PwmInterfaceClient : public ClientAbstract {
     ClientEntry<uint8_t> duty_cycle_;
     ClientEntry<uint8_t> pwm_mode_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubPwmMode + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &pwm_frequency_,  // 0
-            &duty_cycle_,     // 1
-            &pwm_mode_        // 2
-        };
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubPwmMode + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &pwm_frequency_,  // 0
+    //         &duty_cycle_,     // 1
+    //         &pwm_mode_        // 2
+    //     };
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubPwmMode + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubPwmFrequency = 0;

--- a/inc/pwm_interface_client.hpp
+++ b/inc/pwm_interface_client.hpp
@@ -33,21 +33,23 @@ class PwmInterfaceClient : public ClientAbstract {
     ClientEntry<uint8_t> duty_cycle_;
     ClientEntry<uint8_t> pwm_mode_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubPwmMode + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &pwm_frequency_,  // 0
-    //         &duty_cycle_,     // 1
-    //         &pwm_mode_        // 2
-    //     };
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    uint16_t GetNumberOfClientEntries(){
+      return kSubPwmMode + 1;
+    }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubPwmMode + 1;
-   }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      ClientEntryAbstract* entry_array[num_entries] = {
+          &pwm_frequency_,  // 0
+          &duty_cycle_,     // 1
+          &pwm_mode_        // 2
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubPwmFrequency = 0;

--- a/inc/rgb_led.hpp
+++ b/inc/rgb_led.hpp
@@ -26,34 +26,35 @@ class RgbLedClient : public ClientAbstract {
           strobe_pattern_(kTypeRgbLed, obj_idn, kSubStrobePattern){};
 
     // Client Entries
-	ClientEntry<uint8_t> red_;
-	ClientEntry<uint8_t> green_;
-	ClientEntry<uint8_t> blue_;
-	ClientEntryVoid update_color_;
-	ClientEntry<uint8_t> strobe_active_;
-	ClientEntry<float> strobe_period_;
-	ClientEntry<uint32_t> strobe_pattern_;
+    ClientEntry<uint8_t> red_;
+    ClientEntry<uint8_t> green_;
+    ClientEntry<uint8_t> blue_;
+    ClientEntryVoid update_color_;
+    ClientEntry<uint8_t> strobe_active_;
+    ClientEntry<float> strobe_period_;
+    ClientEntry<uint32_t> strobe_pattern_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubStrobePattern + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-		// 	&red_,              // 0
-		// 	&green_,            // 1
-		// 	&blue_,             // 2
-		// 	&update_color_,     // 3
-		// 	&strobe_active_,    // 4
-		// 	&strobe_period_,    // 5
-		// 	&strobe_pattern_    // 6
-    //     };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubStrobePattern + 1;
+    }
 
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubStrobePattern + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &red_,              // 0
+        &green_,            // 1
+        &blue_,             // 2
+        &update_color_,     // 3
+        &strobe_active_,    // 4
+        &strobe_period_,    // 5
+        &strobe_pattern_    // 6
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubRed              = 0;

--- a/inc/rgb_led.hpp
+++ b/inc/rgb_led.hpp
@@ -34,20 +34,26 @@ class RgbLedClient : public ClientAbstract {
 	ClientEntry<float> strobe_period_;
 	ClientEntry<uint32_t> strobe_pattern_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubStrobePattern + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-			&red_,              // 0
-			&green_,            // 1
-			&blue_,             // 2
-			&update_color_,     // 3
-			&strobe_active_,    // 4
-			&strobe_period_,    // 5
-			&strobe_pattern_    // 6
-        };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubStrobePattern + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+		// 	&red_,              // 0
+		// 	&green_,            // 1
+		// 	&blue_,             // 2
+		// 	&update_color_,     // 3
+		// 	&strobe_active_,    // 4
+		// 	&strobe_period_,    // 5
+		// 	&strobe_pattern_    // 6
+    //     };
 
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubStrobePattern + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubRed              = 0;

--- a/inc/serial_interface_client.hpp
+++ b/inc/serial_interface_client.hpp
@@ -30,15 +30,21 @@ class SerialInterfaceClient: public ClientAbstract{
     // Client Entries
     ClientEntry<uint32_t> baud_rate_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubBaudRate+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &baud_rate_,     // 0
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubBaudRate+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &baud_rate_,     // 0
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubBaudRate + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubBaudRate = 0;

--- a/inc/serial_interface_client.hpp
+++ b/inc/serial_interface_client.hpp
@@ -30,21 +30,21 @@ class SerialInterfaceClient: public ClientAbstract{
     // Client Entries
     ClientEntry<uint32_t> baud_rate_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubBaudRate+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &baud_rate_,     // 0
-    //   };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubBaudRate + 1;
+    }
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubBaudRate + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &baud_rate_,     // 0
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubBaudRate = 0;

--- a/inc/servo_input_parser_client.hpp
+++ b/inc/servo_input_parser_client.hpp
@@ -35,23 +35,23 @@ class ServoInputParserClient: public ClientAbstract{
     ClientEntry<float>    unit_min_;
     ClientEntry<float>    unit_max_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubUnitMax+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &mode_,     // 0
-    //     &unit_min_, // 1
-    //     &unit_max_  // 2
-    //   };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubUnitMax + 1;
+    }
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubUnitMax + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &mode_,     // 0
+        &unit_min_, // 1
+        &unit_max_  // 2
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubMode =     0;

--- a/inc/servo_input_parser_client.hpp
+++ b/inc/servo_input_parser_client.hpp
@@ -35,17 +35,23 @@ class ServoInputParserClient: public ClientAbstract{
     ClientEntry<float>    unit_min_;
     ClientEntry<float>    unit_max_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubUnitMax+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &mode_,     // 0
-        &unit_min_, // 1
-        &unit_max_  // 2
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubUnitMax+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &mode_,     // 0
+    //     &unit_min_, // 1
+    //     &unit_max_  // 2
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubUnitMax + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubMode =     0;

--- a/inc/step_direction_input_client.hpp
+++ b/inc/step_direction_input_client.hpp
@@ -33,22 +33,22 @@ class StepDirectionInputClient: public ClientAbstract{
     ClientEntry<float>      angle_;
     ClientEntry<float>      angle_step_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubAngleStep+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &angle_,      // 0
-    //     &angle_step_  // 1
-    //   };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubAngleStep + 1;
+    }
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubAngleStep + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &angle_,      // 0
+        &angle_step_  // 1
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubAngle               = 0;

--- a/inc/step_direction_input_client.hpp
+++ b/inc/step_direction_input_client.hpp
@@ -33,16 +33,22 @@ class StepDirectionInputClient: public ClientAbstract{
     ClientEntry<float>      angle_;
     ClientEntry<float>      angle_step_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubAngleStep+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &angle_,      // 0
-        &angle_step_  // 1
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubAngleStep+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &angle_,      // 0
+    //     &angle_step_  // 1
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubAngleStep + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubAngle               = 0;

--- a/inc/stopping_handler_client.hpp
+++ b/inc/stopping_handler_client.hpp
@@ -31,14 +31,20 @@ class StoppingHandlerClient : public ClientAbstract {
     ClientEntry<float> stopped_speed_;
     ClientEntry<float> stopped_time_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubStoppedTime + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &stopped_speed_,  // 0
-            &stopped_time_    // 1
-        };
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubStoppedTime + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &stopped_speed_,  // 0
+    //         &stopped_time_    // 1
+    //     };
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubStoppedTime + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubStoppedSpeed = 0;

--- a/inc/stopping_handler_client.hpp
+++ b/inc/stopping_handler_client.hpp
@@ -31,20 +31,22 @@ class StoppingHandlerClient : public ClientAbstract {
     ClientEntry<float> stopped_speed_;
     ClientEntry<float> stopped_time_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubStoppedTime + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &stopped_speed_,  // 0
-    //         &stopped_time_    // 1
-    //     };
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    uint16_t GetNumberOfClientEntries(){
+      return kSubStoppedTime + 1;
+    }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubStoppedTime + 1;
-   }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      ClientEntryAbstract* entry_array[num_entries] = {
+          &stopped_speed_,  // 0
+          &stopped_time_    // 1
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubStoppedSpeed = 0;

--- a/inc/stow_user_interface_client.hpp
+++ b/inc/stow_user_interface_client.hpp
@@ -49,23 +49,29 @@ class StowUserInterfaceClient : public ClientAbstract {
     ClientEntry<uint8_t> stow_status_;
     ClientEntry<uint8_t> stow_result_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubStowResult + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &zero_angle_,           // 0
-            &target_angle_,         // 1
-            &target_acceleration_,  // 2
-            &sample_zero_,          // 3
-            &user_stow_request_,    // 4
-            &stow_kp_,              // 5
-            &stow_ki_,              // 6
-            &stow_kd_,              // 7
-            &hold_stow_,            // 8
-            &stow_status_,          // 9
-            &stow_result_           // 10
-        };
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubStowResult + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &zero_angle_,           // 0
+    //         &target_angle_,         // 1
+    //         &target_acceleration_,  // 2
+    //         &sample_zero_,          // 3
+    //         &user_stow_request_,    // 4
+    //         &stow_kp_,              // 5
+    //         &stow_ki_,              // 6
+    //         &stow_kd_,              // 7
+    //         &hold_stow_,            // 8
+    //         &stow_status_,          // 9
+    //         &stow_result_           // 10
+    //     };
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubStowResult + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubZeroAngle          = 0;

--- a/inc/stow_user_interface_client.hpp
+++ b/inc/stow_user_interface_client.hpp
@@ -49,29 +49,31 @@ class StowUserInterfaceClient : public ClientAbstract {
     ClientEntry<uint8_t> stow_status_;
     ClientEntry<uint8_t> stow_result_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubStowResult + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &zero_angle_,           // 0
-    //         &target_angle_,         // 1
-    //         &target_acceleration_,  // 2
-    //         &sample_zero_,          // 3
-    //         &user_stow_request_,    // 4
-    //         &stow_kp_,              // 5
-    //         &stow_ki_,              // 6
-    //         &stow_kd_,              // 7
-    //         &hold_stow_,            // 8
-    //         &stow_status_,          // 9
-    //         &stow_result_           // 10
-    //     };
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    uint16_t GetNumberOfClientEntries(){
+      return kSubStowResult + 1;
+    }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubStowResult + 1;
-   }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      ClientEntryAbstract* entry_array[num_entries] = {
+          &zero_angle_,           // 0
+          &target_angle_,         // 1
+          &target_acceleration_,  // 2
+          &sample_zero_,          // 3
+          &user_stow_request_,    // 4
+          &stow_kp_,              // 5
+          &stow_ki_,              // 6
+          &stow_kd_,              // 7
+          &hold_stow_,            // 8
+          &stow_status_,          // 9
+          &stow_result_           // 10
+      };
+
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubZeroAngle          = 0;

--- a/inc/system_control_client.hpp
+++ b/inc/system_control_client.hpp
@@ -79,39 +79,45 @@ class SystemControlClient : public ClientAbstract {
     ClientEntry<uint32_t> control_flags_;
     ClientEntry<uint32_t> pcb_version_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubPcbVersion + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &reboot_program_,        // 0
-            &reboot_boot_loader_,    // 1
-            &dev_id_,                // 2
-            &rev_id_,                // 3
-            &uid1_,                  // 4
-            &uid2_,                  // 5
-            &uid3_,                  // 6
-            &mem_size_,              // 7
-            &build_year_,            // 8
-            &build_month_,           // 9
-            &build_day_,             // 10
-            &build_hour_,            // 11
-            &build_minute_,          // 12
-            &build_second_,          // 13
-            &module_id_,             // 14
-            &time_,                  // 15
-            &firmware_version_,      // 16
-            &hardware_version_,      // 17
-            &electronics_version_,   // 18
-            &firmware_valid_,        // 19
-            &applications_present_,  // 20
-            &bootloader_version_,    // 21
-            &upgrade_version_,       // 22
-            &system_clock_,          // 23
-            &control_flags_,         // 24
-            &pcb_version_            // 25
-        };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubPcbVersion + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &reboot_program_,        // 0
+    //         &reboot_boot_loader_,    // 1
+    //         &dev_id_,                // 2
+    //         &rev_id_,                // 3
+    //         &uid1_,                  // 4
+    //         &uid2_,                  // 5
+    //         &uid3_,                  // 6
+    //         &mem_size_,              // 7
+    //         &build_year_,            // 8
+    //         &build_month_,           // 9
+    //         &build_day_,             // 10
+    //         &build_hour_,            // 11
+    //         &build_minute_,          // 12
+    //         &build_second_,          // 13
+    //         &module_id_,             // 14
+    //         &time_,                  // 15
+    //         &firmware_version_,      // 16
+    //         &hardware_version_,      // 17
+    //         &electronics_version_,   // 18
+    //         &firmware_valid_,        // 19
+    //         &applications_present_,  // 20
+    //         &bootloader_version_,    // 21
+    //         &upgrade_version_,       // 22
+    //         &system_clock_,          // 23
+    //         &control_flags_,         // 24
+    //         &pcb_version_            // 25
+    //     };
 
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubPcbVersion + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubRebootProgram       = 0;

--- a/inc/system_control_client.hpp
+++ b/inc/system_control_client.hpp
@@ -79,45 +79,46 @@ class SystemControlClient : public ClientAbstract {
     ClientEntry<uint32_t> control_flags_;
     ClientEntry<uint32_t> pcb_version_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubPcbVersion + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &reboot_program_,        // 0
-    //         &reboot_boot_loader_,    // 1
-    //         &dev_id_,                // 2
-    //         &rev_id_,                // 3
-    //         &uid1_,                  // 4
-    //         &uid2_,                  // 5
-    //         &uid3_,                  // 6
-    //         &mem_size_,              // 7
-    //         &build_year_,            // 8
-    //         &build_month_,           // 9
-    //         &build_day_,             // 10
-    //         &build_hour_,            // 11
-    //         &build_minute_,          // 12
-    //         &build_second_,          // 13
-    //         &module_id_,             // 14
-    //         &time_,                  // 15
-    //         &firmware_version_,      // 16
-    //         &hardware_version_,      // 17
-    //         &electronics_version_,   // 18
-    //         &firmware_valid_,        // 19
-    //         &applications_present_,  // 20
-    //         &bootloader_version_,    // 21
-    //         &upgrade_version_,       // 22
-    //         &system_clock_,          // 23
-    //         &control_flags_,         // 24
-    //         &pcb_version_            // 25
-    //     };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubPcbVersion + 1;
+    }
 
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubPcbVersion + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+          &reboot_program_,        // 0
+          &reboot_boot_loader_,    // 1
+          &dev_id_,                // 2
+          &rev_id_,                // 3
+          &uid1_,                  // 4
+          &uid2_,                  // 5
+          &uid3_,                  // 6
+          &mem_size_,              // 7
+          &build_year_,            // 8
+          &build_month_,           // 9
+          &build_day_,             // 10
+          &build_hour_,            // 11
+          &build_minute_,          // 12
+          &build_second_,          // 13
+          &module_id_,             // 14
+          &time_,                  // 15
+          &firmware_version_,      // 16
+          &hardware_version_,      // 17
+          &electronics_version_,   // 18
+          &firmware_valid_,        // 19
+          &applications_present_,  // 20
+          &bootloader_version_,    // 21
+          &upgrade_version_,       // 22
+          &system_clock_,          // 23
+          &control_flags_,         // 24
+          &pcb_version_            // 25
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubRebootProgram       = 0;

--- a/inc/temperature_estimator_client.hpp
+++ b/inc/temperature_estimator_client.hpp
@@ -42,20 +42,26 @@ class TemperatureEstimatorClient: public ClientAbstract{
     ClientEntry<float>    thermal_capacitance_;
     ClientEntry<int32_t>  derate_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubDerate+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &temp_,               // 0
-        &otw_,                // 1
-        &otlo_,               // 2
-        &thermal_resistance_, // 3
-        &thermal_capacitance_,// 4
-        &derate_              // 5
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubDerate+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &temp_,               // 0
+    //     &otw_,                // 1
+    //     &otlo_,               // 2
+    //     &thermal_resistance_, // 3
+    //     &thermal_capacitance_,// 4
+    //     &derate_              // 5
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubDerate + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubTemp =               0;

--- a/inc/temperature_estimator_client.hpp
+++ b/inc/temperature_estimator_client.hpp
@@ -42,26 +42,26 @@ class TemperatureEstimatorClient: public ClientAbstract{
     ClientEntry<float>    thermal_capacitance_;
     ClientEntry<int32_t>  derate_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubDerate+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &temp_,               // 0
-    //     &otw_,                // 1
-    //     &otlo_,               // 2
-    //     &thermal_resistance_, // 3
-    //     &thermal_capacitance_,// 4
-    //     &derate_              // 5
-    //   };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubDerate + 1;
+    }
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubDerate + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &temp_,               // 0
+        &otw_,                // 1
+        &otlo_,               // 2
+        &thermal_resistance_, // 3
+        &thermal_capacitance_,// 4
+        &derate_              // 5
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubTemp =               0;

--- a/inc/temperature_monitor_uc_client.hpp
+++ b/inc/temperature_monitor_uc_client.hpp
@@ -41,26 +41,26 @@ class TemperatureMonitorUcClient: public ClientAbstract{
     ClientEntry<float>    otlo_;
     ClientEntry<float>    derate_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    // {
-    //   static const uint8_t kEntryLength = kSubDerate+1;
-    //   ClientEntryAbstract* entry_array[kEntryLength] = {
-    //     &uc_temp_,    // 0
-    //     &filter_fs_,  // 1
-    //     &filter_fc_,  // 2
-    //     &otw_,        // 3
-    //     &otlo_,       // 4
-    //     &derate_      // 5
-    //   };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubDerate + 1;
+    }
 
-    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubDerate + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &uc_temp_,    // 0
+        &filter_fs_,  // 1
+        &filter_fc_,  // 2
+        &otw_,        // 3
+        &otlo_,       // 4
+        &derate_      // 5
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
   private:
     static const uint8_t kSubUcTemp =   0;

--- a/inc/temperature_monitor_uc_client.hpp
+++ b/inc/temperature_monitor_uc_client.hpp
@@ -41,20 +41,26 @@ class TemperatureMonitorUcClient: public ClientAbstract{
     ClientEntry<float>    otlo_;
     ClientEntry<float>    derate_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
-    {
-      static const uint8_t kEntryLength = kSubDerate+1;
-      ClientEntryAbstract* entry_array[kEntryLength] = {
-        &uc_temp_,    // 0
-        &filter_fs_,  // 1
-        &filter_fc_,  // 2
-        &otw_,        // 3
-        &otlo_,       // 4
-        &derate_      // 5
-      };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length)
+    // {
+    //   static const uint8_t kEntryLength = kSubDerate+1;
+    //   ClientEntryAbstract* entry_array[kEntryLength] = {
+    //     &uc_temp_,    // 0
+    //     &filter_fs_,  // 1
+    //     &filter_fc_,  // 2
+    //     &otw_,        // 3
+    //     &otlo_,       // 4
+    //     &derate_      // 5
+    //   };
 
-      ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //   ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubDerate + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
   private:
     static const uint8_t kSubUcTemp =   0;

--- a/inc/uavcan_node_client.hpp
+++ b/inc/uavcan_node_client.hpp
@@ -52,31 +52,32 @@ class UavcanNodeClient : public ClientAbstract {
     ClientEntry<uint32_t> bit_rate_;
     ClientEntry<uint8_t> bypass_arming_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubBypassArming + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-    //         &uavcan_node_id_,          // 0
-    //         &uavcan_esc_index_,        // 1
-    //         &zero_behavior_,           // 2
-    //         &last_error_code_,         // 3
-    //         &receive_error_counter_,   // 4
-    //         &transmit_error_counter_,  // 5
-    //         &bus_off_flag_,            // 6
-    //         &error_passive_flag_,      // 7
-    //         &error_warning_flag_,      // 8
-    //         &telemetry_frequency_,     // 9
-    //         &bit_rate_,                // 10
-    //         &bypass_arming_            // 11
-    //     };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubBypassArming + 1;
+    }
 
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubBypassArming + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+          &uavcan_node_id_,          // 0
+          &uavcan_esc_index_,        // 1
+          &zero_behavior_,           // 2
+          &last_error_code_,         // 3
+          &receive_error_counter_,   // 4
+          &transmit_error_counter_,  // 5
+          &bus_off_flag_,            // 6
+          &error_passive_flag_,      // 7
+          &error_warning_flag_,      // 8
+          &telemetry_frequency_,     // 9
+          &bit_rate_,                // 10
+          &bypass_arming_            // 11
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubUavcanNodeId         = 0;

--- a/inc/uavcan_node_client.hpp
+++ b/inc/uavcan_node_client.hpp
@@ -52,25 +52,31 @@ class UavcanNodeClient : public ClientAbstract {
     ClientEntry<uint32_t> bit_rate_;
     ClientEntry<uint8_t> bypass_arming_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubBypassArming + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &uavcan_node_id_,          // 0
-            &uavcan_esc_index_,        // 1
-            &zero_behavior_,           // 2
-            &last_error_code_,         // 3
-            &receive_error_counter_,   // 4
-            &transmit_error_counter_,  // 5
-            &bus_off_flag_,            // 6
-            &error_passive_flag_,      // 7
-            &error_warning_flag_,      // 8
-            &telemetry_frequency_,     // 9
-            &bit_rate_,                // 10
-            &bypass_arming_            // 11
-        };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubBypassArming + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+    //         &uavcan_node_id_,          // 0
+    //         &uavcan_esc_index_,        // 1
+    //         &zero_behavior_,           // 2
+    //         &last_error_code_,         // 3
+    //         &receive_error_counter_,   // 4
+    //         &transmit_error_counter_,  // 5
+    //         &bus_off_flag_,            // 6
+    //         &error_passive_flag_,      // 7
+    //         &error_warning_flag_,      // 8
+    //         &telemetry_frequency_,     // 9
+    //         &bit_rate_,                // 10
+    //         &bypass_arming_            // 11
+    //     };
 
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubBypassArming + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubUavcanNodeId         = 0;

--- a/inc/voltage_superposition_client.hpp
+++ b/inc/voltage_superposition_client.hpp
@@ -71,6 +71,36 @@ class VoltageSuperPositionClient : public ClientAbstract {
         ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
     }
 
+   uint16_t GetNumberOfClientEntries(){
+	return kSubPropellerTorqueOffsetAngle + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){
+	ClientEntryAbstract* entry_array[kEntryLength] = {
+		&zero_angle_,                    // 0
+		&frequency_,                     // 1
+		&phase_,                         // 2
+		&amplitude_,                     // 3
+		&voltage_,                       // 4
+		&max_allowed_amplitude_,         // 5
+		&velocity_cutoff_,               // 6
+		&poly_limit_zero_,               // 7
+		&poly_limit_one_,                // 8
+		&poly_limit_two_,                // 9
+		&poly_limit_three_,              // 10
+		&phase_lead_time_,               // 11
+		&phase_lead_angle_,              // 12
+		&phase_act_,                     // 13
+		&amplitude_act_,                 // 14
+		&sample_mechanical_zero_,        // 15
+		&propeller_torque_offset_angle_  // 16
+	};
+
+	for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
+		client_entries[entry] = entry_array[entry];
+	}
+  }
+
    private:
     static const uint8_t kSubZeroAngle                  = 0;
     static const uint8_t kSubFrequency                  = 1;
@@ -89,28 +119,6 @@ class VoltageSuperPositionClient : public ClientAbstract {
     static const uint8_t kSubAmplitudeActual            = 14;
     static const uint8_t kSubSampleMechanicalZero       = 15;
     static const uint8_t kSubPropellerTorqueOffsetAngle = 16;
-
-    static const uint8_t kEntryLength              = kSubPropellerTorqueOffsetAngle + 1;
-    ClientEntryAbstract* entry_array[kEntryLength] = {
-        &zero_angle_,                    // 0
-        &frequency_,                     // 1
-        &phase_,                         // 2
-        &amplitude_,                     // 3
-        &voltage_,                       // 4
-        &max_allowed_amplitude_,         // 5
-        &velocity_cutoff_,               // 6
-        &poly_limit_zero_,               // 7
-        &poly_limit_one_,                // 8
-        &poly_limit_two_,                // 9
-        &poly_limit_three_,              // 10
-        &phase_lead_time_,               // 11
-        &phase_lead_angle_,              // 12
-        &phase_act_,                     // 13
-        &amplitude_act_,                 // 14
-        &sample_mechanical_zero_,        // 15
-        &propeller_torque_offset_angle_  // 16
-
-    };
 };
 
 #endif

--- a/inc/voltage_superposition_client.hpp
+++ b/inc/voltage_superposition_client.hpp
@@ -89,6 +89,32 @@ class VoltageSuperPositionClient : public ClientAbstract {
         ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
     }
 
+    void UpdateEntryIds(uint8_t new_id){
+        static const uint8_t kEntryLength = kSubPropellerTorqueOffsetAngle + 1;
+        ClientEntryAbstract* entry_array[kEntryLength] = {
+            &zero_angle_,                    // 0
+            &frequency_,                     // 1
+            &phase_,                         // 2
+            &amplitude_,                     // 3
+            &voltage_,                       // 4
+            &max_allowed_amplitude_,         // 5
+            &velocity_cutoff_,               // 6
+            &poly_limit_zero_,               // 7
+            &poly_limit_one_,                // 8
+            &poly_limit_two_,                // 9
+            &poly_limit_three_,              // 10
+            &phase_lead_time_,               // 11
+            &phase_lead_angle_,              // 12
+            &phase_act_,                     // 13
+            &amplitude_act_,                 // 14
+            &sample_mechanical_zero_,        // 15
+            &propeller_torque_offset_angle_  // 16
+        };
+
+        UpdateEntryIdsFromList(entry_array, kEntryLength, new_id);
+    }
+
+
    private:
     static const uint8_t kSubZeroAngle                  = 0;
     static const uint8_t kSubFrequency                  = 1;

--- a/inc/voltage_superposition_client.hpp
+++ b/inc/voltage_superposition_client.hpp
@@ -42,7 +42,11 @@ class VoltageSuperPositionClient : public ClientAbstract {
           amplitude_act_(kTypeVoltageSuperposition, obj_idn, kSubAmplitudeActual),
           sample_mechanical_zero_(kTypeVoltageSuperposition, obj_idn, kSubSampleMechanicalZero),
           propeller_torque_offset_angle_(kTypeVoltageSuperposition, obj_idn,
-                                         kSubPropellerTorqueOffsetAngle){};
+                                         kSubPropellerTorqueOffsetAngle)
+          {
+            entry_array_head = entry_array;
+            num_entries = kEntryLength;
+          };
 
     // Client Entries
     ClientEntry<float> zero_angle_;
@@ -64,56 +68,8 @@ class VoltageSuperPositionClient : public ClientAbstract {
     ClientEntry<float> propeller_torque_offset_angle_;
 
     void ReadMsg(uint8_t* rx_data, uint8_t rx_length) override {
-        static const uint8_t kEntryLength              = kSubPropellerTorqueOffsetAngle + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &zero_angle_,                    // 0
-            &frequency_,                     // 1
-            &phase_,                         // 2
-            &amplitude_,                     // 3
-            &voltage_,                       // 4
-            &max_allowed_amplitude_,         // 5
-            &velocity_cutoff_,               // 6
-            &poly_limit_zero_,               // 7
-            &poly_limit_one_,                // 8
-            &poly_limit_two_,                // 9
-            &poly_limit_three_,              // 10
-            &phase_lead_time_,               // 11
-            &phase_lead_angle_,              // 12
-            &phase_act_,                     // 13
-            &amplitude_act_,                 // 14
-            &sample_mechanical_zero_,        // 15
-            &propeller_torque_offset_angle_  // 16
-
-        };
-
         ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
     }
-
-    void UpdateEntryIds(uint8_t new_id){
-        static const uint8_t kEntryLength = kSubPropellerTorqueOffsetAngle + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-            &zero_angle_,                    // 0
-            &frequency_,                     // 1
-            &phase_,                         // 2
-            &amplitude_,                     // 3
-            &voltage_,                       // 4
-            &max_allowed_amplitude_,         // 5
-            &velocity_cutoff_,               // 6
-            &poly_limit_zero_,               // 7
-            &poly_limit_one_,                // 8
-            &poly_limit_two_,                // 9
-            &poly_limit_three_,              // 10
-            &phase_lead_time_,               // 11
-            &phase_lead_angle_,              // 12
-            &phase_act_,                     // 13
-            &amplitude_act_,                 // 14
-            &sample_mechanical_zero_,        // 15
-            &propeller_torque_offset_angle_  // 16
-        };
-
-        UpdateEntryIdsFromList(entry_array, kEntryLength, new_id);
-    }
-
 
    private:
     static const uint8_t kSubZeroAngle                  = 0;
@@ -133,6 +89,28 @@ class VoltageSuperPositionClient : public ClientAbstract {
     static const uint8_t kSubAmplitudeActual            = 14;
     static const uint8_t kSubSampleMechanicalZero       = 15;
     static const uint8_t kSubPropellerTorqueOffsetAngle = 16;
+
+    static const uint8_t kEntryLength              = kSubPropellerTorqueOffsetAngle + 1;
+    ClientEntryAbstract* entry_array[kEntryLength] = {
+        &zero_angle_,                    // 0
+        &frequency_,                     // 1
+        &phase_,                         // 2
+        &amplitude_,                     // 3
+        &voltage_,                       // 4
+        &max_allowed_amplitude_,         // 5
+        &velocity_cutoff_,               // 6
+        &poly_limit_zero_,               // 7
+        &poly_limit_one_,                // 8
+        &poly_limit_two_,                // 9
+        &poly_limit_three_,              // 10
+        &phase_lead_time_,               // 11
+        &phase_lead_angle_,              // 12
+        &phase_act_,                     // 13
+        &amplitude_act_,                 // 14
+        &sample_mechanical_zero_,        // 15
+        &propeller_torque_offset_angle_  // 16
+
+    };
 };
 
 #endif

--- a/inc/voltage_superposition_client.hpp
+++ b/inc/voltage_superposition_client.hpp
@@ -44,8 +44,6 @@ class VoltageSuperPositionClient : public ClientAbstract {
           propeller_torque_offset_angle_(kTypeVoltageSuperposition, obj_idn,
                                          kSubPropellerTorqueOffsetAngle)
           {
-            entry_array_head = entry_array;
-            num_entries = kEntryLength;
           };
 
     // Client Entries
@@ -67,39 +65,37 @@ class VoltageSuperPositionClient : public ClientAbstract {
     ClientEntryVoid sample_mechanical_zero_;
     ClientEntry<float> propeller_torque_offset_angle_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) override {
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    uint16_t GetNumberOfClientEntries(){
+      return kSubPropellerTorqueOffsetAngle + 1;
     }
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubPropellerTorqueOffsetAngle + 1;
-   }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){
-	ClientEntryAbstract* entry_array[kEntryLength] = {
-		&zero_angle_,                    // 0
-		&frequency_,                     // 1
-		&phase_,                         // 2
-		&amplitude_,                     // 3
-		&voltage_,                       // 4
-		&max_allowed_amplitude_,         // 5
-		&velocity_cutoff_,               // 6
-		&poly_limit_zero_,               // 7
-		&poly_limit_one_,                // 8
-		&poly_limit_two_,                // 9
-		&poly_limit_three_,              // 10
-		&phase_lead_time_,               // 11
-		&phase_lead_angle_,              // 12
-		&phase_act_,                     // 13
-		&amplitude_act_,                 // 14
-		&sample_mechanical_zero_,        // 15
-		&propeller_torque_offset_angle_  // 16
-	};
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &zero_angle_,                    // 0
+        &frequency_,                     // 1
+        &phase_,                         // 2
+        &amplitude_,                     // 3
+        &voltage_,                       // 4
+        &max_allowed_amplitude_,         // 5
+        &velocity_cutoff_,               // 6
+        &poly_limit_zero_,               // 7
+        &poly_limit_one_,                // 8
+        &poly_limit_two_,                // 9
+        &poly_limit_three_,              // 10
+        &phase_lead_time_,               // 11
+        &phase_lead_angle_,              // 12
+        &phase_act_,                     // 13
+        &amplitude_act_,                 // 14
+        &sample_mechanical_zero_,        // 15
+        &propeller_torque_offset_angle_  // 16
+      };
 
-	for(uint16_t entry = 0; entry < GetNumberOfClientEntries(); entry++){
-		client_entries[entry] = entry_array[entry];
-	}
-  }
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubZeroAngle                  = 0;

--- a/inc/white_led.hpp
+++ b/inc/white_led.hpp
@@ -28,23 +28,24 @@ class WhiteLedClient : public ClientAbstract {
 	ClientEntry<float> strobe_period_;
 	ClientEntry<uint32_t> strobe_pattern_;
 
-    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-    //     static const uint8_t kEntryLength              = kSubStrobePattern + 1;
-    //     ClientEntryAbstract* entry_array[kEntryLength] = {
-		// 	&intensity_,        // 0
-		// 	&strobe_active_,    // 1
-		// 	&strobe_period_,    // 2
-		// 	&strobe_pattern_    // 3
-    //     };
+    uint16_t GetNumberOfClientEntries(){
+      return kSubStrobePattern + 1;
+    }
 
-    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    // }
+    void GetClientEntryList(ClientEntryAbstract ** client_entries){
+      uint16_t num_entries = GetNumberOfClientEntries();
 
-   uint16_t GetNumberOfClientEntries(){
-	return kSubStrobePattern + 1;
-   }
+      ClientEntryAbstract* entry_array[num_entries] = {
+        &intensity_,        // 0
+        &strobe_active_,    // 1
+        &strobe_period_,    // 2
+        &strobe_pattern_    // 3
+      };
 
-  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
+      for(uint16_t entry = 0; entry < num_entries; entry++){
+        client_entries[entry] = entry_array[entry];
+      }
+    }
 
    private:
     static const uint8_t kSubIntensity        = 0;

--- a/inc/white_led.hpp
+++ b/inc/white_led.hpp
@@ -28,17 +28,23 @@ class WhiteLedClient : public ClientAbstract {
 	ClientEntry<float> strobe_period_;
 	ClientEntry<uint32_t> strobe_pattern_;
 
-    void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
-        static const uint8_t kEntryLength              = kSubStrobePattern + 1;
-        ClientEntryAbstract* entry_array[kEntryLength] = {
-			&intensity_,        // 0
-			&strobe_active_,    // 1
-			&strobe_period_,    // 2
-			&strobe_pattern_    // 3
-        };
+    // void ReadMsg(uint8_t* rx_data, uint8_t rx_length) {
+    //     static const uint8_t kEntryLength              = kSubStrobePattern + 1;
+    //     ClientEntryAbstract* entry_array[kEntryLength] = {
+		// 	&intensity_,        // 0
+		// 	&strobe_active_,    // 1
+		// 	&strobe_period_,    // 2
+		// 	&strobe_pattern_    // 3
+    //     };
 
-        ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
-    }
+    //     ParseMsg(rx_data, rx_length, entry_array, kEntryLength);
+    // }
+
+   uint16_t GetNumberOfClientEntries(){
+	return kSubStrobePattern + 1;
+   }
+
+  void GetClientEntryList(ClientEntryAbstract ** client_entries){}
 
    private:
     static const uint8_t kSubIntensity        = 0;


### PR DESCRIPTION
This update allows us to dynamically change the module ID used by clients and client entries. On the PX4 end, it means we no longer need to dynamically create and destroy objects, we only need to update their IDs.

Testing completed is here: https://docs.google.com/document/d/1DAN8xCS-4drk1yEgcYF9B2IV5Dzwu2wrhJ4ESRSKPDc/edit?usp=sharing